### PR TITLE
Address maven warnings (Issue #66)

### DIFF
--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -50,13 +50,6 @@
       </testResource>
     </testResources>
     <plugins>
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-            <skipTests>true</skipTests>
-        </configuration>
-    </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
@@ -211,6 +204,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skipTests>true</skipTests>
           <properties>
             <property>
               <name>listener</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
         <!-- Plugin Dependencies -->
         <maven.assembly.version>2.4</maven.assembly.version>
         <maven.antrun.version>1.6</maven.antrun.version>
+        <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
+        <maven-eclipse-plugin.version>2.3-INTERNAL-r489210</maven-eclipse-plugin.version>
+        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <jamon.plugin.version>2.3.4</jamon.plugin.version>
         <build-helper.plugin.version>1.5</build-helper.plugin.version>
         <findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>
@@ -140,6 +144,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${findbugs-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <inherited>false</inherited>
@@ -159,6 +164,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -172,6 +178,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
                     <executions>
                         <execution>
                             <phase>prepare-package</phase>
@@ -244,6 +251,16 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-eclipse-plugin</artifactId>
+                    <version>${maven-eclipse-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The patch addresses some warnings caused by improperly setup maven. Some version strings were missing from the parent pom, and a plugin section was duplicated in hbase-server.
