### PR TITLE
Uniform handling of ASF copyright notices in C5DB files

### DIFF
--- a/c5db-client/bin/genproto
+++ b/c5db-client/bin/genproto
@@ -15,9 +15,6 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#   This file incorporates work covered by the following copyright and
-#   permission notice:
-#
 
 (cd src/main/resources/ ; protoc *.proto --java_out=../java)
 

--- a/c5db-client/src/main/java/c5db/ProtobufUtil.java
+++ b/c5db-client/src/main/java/c5db/ProtobufUtil.java
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/main/java/c5db/RequestConverter.java
+++ b/c5db-client/src/main/java/c5db/RequestConverter.java
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -35,6 +33,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package c5db;
 
 import c5db.client.generated.ClientProtos;

--- a/c5db-client/src/main/java/c5db/client/C5Constants.java
+++ b/c5db-client/src/main/java/c5db/client/C5Constants.java
@@ -13,11 +13,7 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
-
 package c5db.client;
 
 public class C5Constants {

--- a/c5db-client/src/main/java/c5db/client/C5Shim.java
+++ b/c5db-client/src/main/java/c5db/client/C5Shim.java
@@ -13,11 +13,7 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
-
 package c5db.client;
 
 

--- a/c5db-client/src/main/java/c5db/client/C5Table.java
+++ b/c5db-client/src/main/java/c5db/client/C5Table.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2013  Ohm Data
  *
@@ -14,11 +13,7 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
-
 package c5db.client;
 
 import c5db.ProtobufUtil;
@@ -30,8 +25,6 @@ import c5db.client.scanner.ClientScannerManager;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandler;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;

--- a/c5db-client/src/main/java/c5db/client/TableInterface.java
+++ b/c5db-client/src/main/java/c5db/client/TableInterface.java
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/main/java/c5db/client/scanner/ClientScanner.java
+++ b/c5db-client/src/main/java/c5db/client/scanner/ClientScanner.java
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -35,7 +33,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 package c5db.client.scanner;
 

--- a/c5db-client/src/main/resources/Cell.proto
+++ b/c5db-client/src/main/resources/Cell.proto
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/main/resources/Client.proto
+++ b/c5db-client/src/main/resources/Client.proto
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/main/resources/Comparator.proto
+++ b/c5db-client/src/main/resources/Comparator.proto
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/main/resources/Filter.proto
+++ b/c5db-client/src/main/resources/Filter.proto
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/main/resources/HBase.proto
+++ b/c5db-client/src/main/resources/HBase.proto
@@ -13,12 +13,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
-/**
+/** Incorporates changes licensed under:
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/c5db-client/src/test/java/c5db/TestProto.java
+++ b/c5db-client/src/test/java/c5db/TestProto.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 
 /**

--- a/c5db/src/main/resources/Log.proto
+++ b/c5db/src/main/resources/Log.proto
@@ -13,10 +13,8 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
+
 package c5db.log;
 
 option java_package = "c5db.generated";

--- a/c5db/src/main/resources/RegionRegistryLine.proto
+++ b/c5db/src/main/resources/RegionRegistryLine.proto
@@ -13,10 +13,8 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
+
 package c5db.log;
 
 option java_package = "c5db.generated";

--- a/c5db/src/main/resources/beacon.proto
+++ b/c5db/src/main/resources/beacon.proto
@@ -13,10 +13,8 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
+
 package c5db.election;
 
 option java_package = "c5db.discovery.generated";

--- a/c5db/src/main/resources/control_messages.proto
+++ b/c5db/src/main/resources/control_messages.proto
@@ -13,10 +13,8 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
+
 package c5db.messages;
 
 option java_package = "c5db.messages.generated";

--- a/c5db/src/main/resources/replication_messages.proto
+++ b/c5db/src/main/resources/replication_messages.proto
@@ -13,10 +13,8 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
+
 package c5db.replication;
 
 option java_package = "c5db.replication.generated";

--- a/c5db/src/test/java/c5db/client/CompareToHBase.java
+++ b/c5db/src/test/java/c5db/client/CompareToHBase.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 package c5db.client;
 

--- a/c5db/src/test/java/c5db/client/HBasePop.java
+++ b/c5db/src/test/java/c5db/client/HBasePop.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 package c5db.client;
 

--- a/c5db/src/test/java/c5db/client/Populator.java
+++ b/c5db/src/test/java/c5db/client/Populator.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 package c5db.client;
 

--- a/c5db/src/test/java/c5db/client/TestInOrderScan.java
+++ b/c5db/src/test/java/c5db/client/TestInOrderScan.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 package c5db.client;
 
@@ -24,7 +21,6 @@ import com.google.protobuf.ByteString;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;

--- a/c5db/src/test/java/c5db/client/TestMultiUtil.java
+++ b/c5db/src/test/java/c5db/client/TestMultiUtil.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 package c5db.client;
 

--- a/c5db/src/test/java/c5db/client/TestScanner.java
+++ b/c5db/src/test/java/c5db/client/TestScanner.java
@@ -13,9 +13,6 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *  This file incorporates work covered by the following copyright and
- *  permission notice:
  */
 package c5db.client;
 


### PR DESCRIPTION
This patch fixes several cases where ASF copyright notices were missing. In most cases, the files had the line "This file incorporates work covered by the following copyright and permission notice:", but there was no  actual copyright notice after that line. Presumably IntelliJ got rid of them.

The handling of these cases should now be standard, like so:

/*\* 
 &#x0002A; &lt;AGPL3 license&gt;
 &#x0002A;/
&lt;blank line&gt;
/*\* Incorporates changes licensed under:
 &#x0002A; &lt;ASF license&gt;
 &#x0002A;/
