### PR TITLE
Change log interface to specify asynchronous gets (Issue #40)

### DIFF
--- a/c5db/src/main/java/c5db/log/Mooring.java
+++ b/c5db/src/main/java/c5db/log/Mooring.java
@@ -20,6 +20,7 @@ import c5db.generated.Log;
 import c5db.replication.ReplicatorLogAbstraction;
 import c5db.replication.generated.LogEntry;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 
 import java.util.ArrayList;
@@ -58,10 +59,26 @@ public class Mooring implements ReplicatorLogAbstraction {
         return this.log.logEntry(oLogEntries, quorumId);
     }
 
-    @Override
-    public LogEntry getLogEntry(long index) {
-        return this.log.getLogEntry(index, quorumId);
+  @Override
+  public ListenableFuture<LogEntry> getLogEntry(long index) {
+    // TODO replace with an async implementation
+    SettableFuture<LogEntry> future = SettableFuture.create();
+    future.set(this.log.getLogEntry(index, quorumId));
+    return future;
+  }
+
+  @Override
+  public ListenableFuture<List<LogEntry>> getLogEntries(long start, long end) {
+    // TODO replace with an async implementation and retrieve entries in a batch
+    SettableFuture<List<LogEntry>> future = SettableFuture.create();
+    ArrayList<LogEntry> entries = new ArrayList<>();
+    for (long i = start; i < end; i++) {
+      LogEntry entry = log.getLogEntry(i, quorumId);
+      entries.add(entry);
     }
+    future.set(entries);
+    return future;
+  }
 
     @Override
     public long getLogTerm(long index) {

--- a/c5db/src/main/java/c5db/replication/InRamLog.java
+++ b/c5db/src/main/java/c5db/replication/InRamLog.java
@@ -14,6 +14,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package c5db.replication;
 
 import c5db.replication.generated.LogEntry;
@@ -28,60 +29,75 @@ import java.util.List;
  */
 public class InRamLog implements ReplicatorLogAbstraction {
 
-    private final ArrayList<LogEntry> log = new ArrayList<>();
+  private final ArrayList<LogEntry> log = new ArrayList<>();
 
-    public InRamLog() {
+  public InRamLog() {
+  }
+
+  @Override
+  public ListenableFuture<Boolean> logEntries(List<LogEntry> entries) {
+    // add them, for great justice.
+
+    assert (entries.isEmpty()) || ((log.size() + 1) == entries.get(0).getIndex());
+    // TODO more assertions
+
+    log.addAll(entries);
+
+
+    SettableFuture<Boolean> r = SettableFuture.create();
+    r.set(true);
+    return r;
+  }
+
+  @Override
+  public ListenableFuture<LogEntry> getLogEntry(long index) {
+    assert index > 0;
+    SettableFuture<LogEntry> future = SettableFuture.create();
+    if (index - 1 >= log.size()) {
+      future.set(null);
+    } else {
+      future.set(log.get((int) index - 1));
     }
+    return future;
+  }
 
-    @Override
-    public ListenableFuture<Boolean> logEntries(List<LogEntry> entries) {
-        // add them, for great justice.
+  @Override
+  public ListenableFuture<List<LogEntry>> getLogEntries(long start, long end) {
+    assert start > 0;
+    assert end >= start;
 
-        assert (entries.isEmpty()) || ((log.size() + 1) == entries.get(0).getIndex());
-        // TODO more assertions
+    SettableFuture<List<LogEntry>> future = SettableFuture.create();
+    future.set(log.subList((int) start - 1, (int) end - 1));
+    return future;
+  }
 
-        log.addAll(entries);
-
-
-        SettableFuture<Boolean> r = SettableFuture.create();
-        r.set(true);
-        return r;
+  @Override
+  public synchronized long getLogTerm(long index) {
+    assert index > 0;
+    if (index - 1 >= log.size()) {
+      return 0;
     }
+    return log.get((int) index - 1).getTerm();
+  }
 
-    @Override
-    public LogEntry getLogEntry(long index) {
-        assert index > 0;
-        if (index - 1 >= log.size()) {
-          return null;
-        }
-        return log.get((int) index - 1);
+  @Override
+  public synchronized long getLastTerm() {
+    if (log.isEmpty()) {
+      return 0;
     }
+    return log.get(log.size() - 1).getTerm();
+  }
 
-    @Override
-    public synchronized long getLogTerm(long index) {
-        assert index > 0;
-        if (index - 1 >= log.size()) {
-          return 0;
-        }
-        return log.get((int) index - 1).getTerm();
-    }
+  @Override
+  public synchronized long getLastIndex() {
+    return log.size();
+  }
 
-    @Override
-    public synchronized long getLastTerm() {
-        if (log.isEmpty()) return 0;
-        return log.get(log.size() - 1).getTerm();
-    }
-
-    @Override
-    public synchronized long getLastIndex() {
-        return log.size();
-    }
-
-    @Override
-    public synchronized ListenableFuture<Boolean> truncateLog(long entryIndex) {
-        log.subList((int) entryIndex - 1, log.size()).clear();
-        SettableFuture<Boolean> r = SettableFuture.create();
-        r.set(true);
-        return r;
-    }
+  @Override
+  public synchronized ListenableFuture<Boolean> truncateLog(long entryIndex) {
+    log.subList((int) entryIndex - 1, log.size()).clear();
+    SettableFuture<Boolean> r = SettableFuture.create();
+    r.set(true);
+    return r;
+  }
 }

--- a/c5db/src/main/java/c5db/replication/ReplicatorInstance.java
+++ b/c5db/src/main/java/c5db/replication/ReplicatorInstance.java
@@ -834,9 +834,8 @@ public class ReplicatorInstance implements ReplicationModule.Replicator {
             // for each peer, figure out how many "back messages" should I send:
             final long peerNextIdx = this.peersNextIndex.get(peer);
 
-            ArrayList<LogEntry> peerEntries = newLogEntries;
             if (peerNextIdx < firstInList) {
-                long moreCount = firstInList - peerNextIdx;
+                final long moreCount = firstInList - peerNextIdx;
                 LOG.debug("{} sending {} more log entires to peer {}", myId, moreCount, peer);
 
                 // TODO check moreCount is reasonable, and available in log. Otherwise do alternative peer catch up
@@ -845,65 +844,95 @@ public class ReplicatorInstance implements ReplicationModule.Replicator {
                 // TODO allow for smaller 'catch up' messages so we dont try to create a 400GB sized message.
 
                 // TODO cache these extra LogEntry objects so we dont recreate too many of them.
-                peerEntries = new ArrayList<>((int) (newLogEntries.size() + moreCount));
-                for (long i = peerNextIdx; i < firstInList; i++) {
-                    LogEntry entry = log.getLogEntry(i);
-                    peerEntries.add(entry);
-                }
-                // TODO make sure the lists splice neatly together. The check below fails when newLogEntries is empty
-                //assert (peerEntries.get(peerEntries.size()-1).getIndex()+1) == newLogEntries.get(0).getIndex();
-                peerEntries.addAll(newLogEntries);
-            }
 
-            final long prevLogIndex = peerNextIdx - 1;
-            final long prevLogTerm;
-            if (prevLogIndex == 0) {
-              prevLogTerm = 0;
+                ListenableFuture<List<LogEntry>> peerEntriesFuture = log.getLogEntries(peerNextIdx, firstInList);
+
+                Futures.addCallback(peerEntriesFuture, new FutureCallback<List<LogEntry>>() {
+                  @Override
+                  public void onSuccess(List<LogEntry> entriesFromLog) {
+                    // TODO make sure the lists splice neatly together.
+                    assert entriesFromLog.size() == moreCount;
+                    if (peerNextIdx != peersNextIndex.get(peer) ||
+                        myState != State.LEADER) {
+                      // These were the same when we started checking the log, but they're not now -- that means
+                      // things happened while the log was retrieving, so discard this result. This is safe because
+                      // the next (or concurrent) run of consumeQueue has better information.
+                      return;
+                    }
+
+                    List<LogEntry> entriesToAppend = new ArrayList<>((int) (newLogEntries.size() + moreCount));
+                    entriesToAppend.addAll(entriesFromLog);
+                    entriesToAppend.addAll(newLogEntries);
+                    sendAppendEntries(peer, peerNextIdx, lastIndexSent, majority, entriesToAppend);
+                  }
+
+                  @Override
+                  public void onFailure(Throwable throwable) {
+                    // Failed to retrieve from local log
+                    // TODO is this situation ever recoverable?
+                    failReplicatorInstance(throwable);
+                  }
+                });
             } else {
-              prevLogTerm = log.getLogTerm(prevLogIndex);
+              sendAppendEntries(peer, peerNextIdx, lastIndexSent, majority, newLogEntries);
             }
-
-            // catch them up so the next RPC wont over-send old junk.
-            peersNextIndex.put(peer, lastIndexSent + 1);
-
-            AppendEntries msg = new AppendEntries(
-                    currentTerm, myId, prevLogIndex, prevLogTerm,
-                    peerEntries,
-                    lastCommittedIndex
-            );
-
-            RpcRequest request = new RpcRequest(peer, myId, quorumId, msg);
-            AsyncRequest.withOneReply(fiber, sendRpcChannel, request, new Callback<RpcWireReply>() {
-                @Override
-                public void onMessage(RpcWireReply message) {
-                    LOG.trace("{} got a reply {}", myId, message);
-
-                    boolean wasSuccessful = message.getAppendReplyMessage().getSuccess();
-                    if (!wasSuccessful) {
-                        // This is per Page 7, paragraph 5.  "After a rejection, the leader decrements nextIndex and retries"
-                        if (message.getAppendReplyMessage().getMyLastLogEntry() != 0) {
-                            peersNextIndex.put(peer, message.getAppendReplyMessage().getMyLastLogEntry());
-                        } else {
-                            peersNextIndex.put(peer, peerNextIdx - 1);
-                        }
-                    } else {
-                        // we have been successfully acked up to this point.
-                        LOG.trace("{} peer {} acked for {}", myId, peer, lastIndexSent);
-                        peersLastAckedIndex.put(peer, lastIndexSent);
-
-                        calculateLastVisible(majority, lastIndexSent);
-                    }
-                }
-            }, 5, TimeUnit.SECONDS, new Runnable() {
-                        @Override
-                        public void run() {
-                            LOG.trace("{} peer {} timed out", myId, peer);
-                            // Do nothing -> let next timeout handle things.
-                            // This timeout exists just so that we can cancel and clean up stuff in jetlang.
-                        }
-                    }
-            );
         }
+    }
+
+    @FiberOnly
+    private void sendAppendEntries(long peer, long peerNextIdx, long lastIndexSent, long majority,
+                                   final List<LogEntry> entries) {
+      assert (entries.size() == 0) || (entries.get(0).getIndex() == peerNextIdx);
+      assert (entries.size() == 0) || (entries.get(entries.size() - 1).getIndex() == lastIndexSent);
+
+      final long prevLogIndex = peerNextIdx - 1;
+      final long prevLogTerm;
+      if (prevLogIndex == 0) {
+        prevLogTerm = 0;
+      } else {
+        prevLogTerm = log.getLogTerm(prevLogIndex);
+      }
+
+      // catch them up so the next RPC wont over-send old junk.
+      peersNextIndex.put(peer, lastIndexSent + 1);
+
+      AppendEntries msg = new AppendEntries(
+              currentTerm, myId, prevLogIndex, prevLogTerm,
+              entries,
+              lastCommittedIndex
+      );
+
+      RpcRequest request = new RpcRequest(peer, myId, quorumId, msg);
+      AsyncRequest.withOneReply(fiber, sendRpcChannel, request, new Callback<RpcWireReply>() {
+          @Override
+          public void onMessage(RpcWireReply message) {
+              LOG.trace("{} got a reply {}", myId, message);
+
+              boolean wasSuccessful = message.getAppendReplyMessage().getSuccess();
+              if (!wasSuccessful) {
+                  // This is per Page 7, paragraph 5.  "After a rejection, the leader decrements nextIndex and retries"
+                  if (message.getAppendReplyMessage().getMyLastLogEntry() != 0) {
+                      peersNextIndex.put(peer, message.getAppendReplyMessage().getMyLastLogEntry());
+                  } else {
+                      peersNextIndex.put(peer, peerNextIdx - 1);
+                  }
+              } else {
+                  // we have been successfully acked up to this point.
+                  LOG.trace("{} peer {} acked for {}", myId, peer, lastIndexSent);
+                  peersLastAckedIndex.put(peer, lastIndexSent);
+
+                  calculateLastVisible(majority, lastIndexSent);
+              }
+          }
+      }, 5, TimeUnit.SECONDS, new Runnable() {
+                  @Override
+                  public void run() {
+                      LOG.trace("{} peer {} timed out", myId, peer);
+                      // Do nothing -> let next timeout handle things.
+                      // This timeout exists just so that we can cancel and clean up stuff in jetlang.
+                  }
+              }
+      );
     }
 
     private void calculateLastVisible(long majority, long lastIndexSent) {

--- a/c5db/src/main/java/c5db/replication/ReplicatorLogAbstraction.java
+++ b/c5db/src/main/java/c5db/replication/ReplicatorLogAbstraction.java
@@ -48,20 +48,30 @@ public interface ReplicatorLogAbstraction {
     public ListenableFuture<Boolean> logEntries(List<LogEntry> entries);
 
     /**
-     * Get the entry for a given log index. If the given index is not present in the log, then this
-     * will return null.
+     * Get a future which will return the entry for a given log index. If the given index is not
+     * present in the log, then this future will return null.
      *
-     * @param index
-     * @return the entry at 'index', or null if no such entry
+     * @param index the index to retrieve
+     * @return a future which will yield the entry at 'index', or null if no such entry
      */
-    public LogEntry getLogEntry(long index);
+    public ListenableFuture<LogEntry> getLogEntry(long index);
+
+    /**
+     * Get a future which will return the entries in a specified range of indexes from start, inclusive, to end,
+     * exclusive. If start and end are equal, the returned list will be empty.
+     *
+     * @param start the index of the low endpoint of the range (inclusive)
+     * @param end the index of the high endpoint of the range (exclusive)
+     * @return a future which will yield the specified entries, or an empty list if there are none
+     */
+    public ListenableFuture<List<LogEntry>> getLogEntries(long start, long end);
 
     /**
      * Get the term for a given log index. If the given index is not present in the log, then this
      * will return 0. A term value of 0 should be considered invalid. This is expected to be fast,
      * so it's a synchronous interface.
      *
-     * @param index
+     * @param index the index to look up the term for
      * @return the term value at 'index', or 0 if no such entry
      */
     public long getLogTerm(long index);

--- a/c5db/src/test/java/c5db/replication/InRamAppendEntriesTest.java
+++ b/c5db/src/test/java/c5db/replication/InRamAppendEntriesTest.java
@@ -233,7 +233,7 @@ public class InRamAppendEntriesTest {
   }
 
   @Test
-  public void testTermConflictAtMostRecentLogEntry() throws InterruptedException {
+  public void testTermConflictAtMostRecentLogEntry() throws Exception {
     // "If an existing entry conflicts with a new one (same index but different terms),
     // delete the existing entry and all that follow it (§5.3)"
     // This tests the case where the conflict is the most recent entry.
@@ -247,14 +247,14 @@ public class InRamAppendEntriesTest {
     syncSendMessage(rpcFiber, LEADER_ID, repl,
         new AppendEntries(messageTerm, LEADER_ID, prevLogIndex, prevLogTerm, Lists.newArrayList(entry), 0));
 
-    assertNotEquals(3, log.getLogEntry(5).getTerm());
-    assertEquals(4, log.getLogEntry(5).getTerm());
+    assertNotEquals(3, log.getLogEntry(5).get().getTerm());
+    assertEquals(4, log.getLogEntry(5).get().getTerm());
     assertEquals(5, log.getLastIndex());
     assertEquals(4, log.getLastTerm());
   }
 
   @Test
-  public void testTermConflictAtPreviousEntry() throws InterruptedException {
+  public void testTermConflictAtPreviousEntry() throws Exception {
     // "If an existing entry conflicts with a new one (same index but different terms),
     // delete the existing entry and all that follow it (§5.3)"
     // This tests the case where the conflict is not the most recent entry.
@@ -268,10 +268,10 @@ public class InRamAppendEntriesTest {
     syncSendMessage(rpcFiber, LEADER_ID, repl,
         new AppendEntries(messageTerm, LEADER_ID, prevLogIndex, prevLogTerm, Lists.newArrayList(entry), 0));
 
-    assertNotEquals(2, log.getLogEntry(3).getTerm());
-    assertEquals(4, log.getLogEntry(3).getTerm());
-    assertNull(log.getLogEntry(4));
-    assertNull(log.getLogEntry(5));
+    assertNotEquals(2, log.getLogEntry(3).get().getTerm());
+    assertEquals(4, log.getLogEntry(3).get().getTerm());
+    assertNull(log.getLogEntry(4).get());
+    assertNull(log.getLogEntry(5).get());
     assertEquals(3, log.getLastIndex());
     assertEquals(4, log.getLastTerm());
   }


### PR DESCRIPTION
This patch does the following:
- add a get method to ReplicatorLogAbstraction to retrieve a range of log indices (rather than just one)
- change ReplicatorLogAbstraction so its get methods return futures
- modify all implementing classes and tests to return futures (though the underlying logic is still synchronous)
- modify ReplicatorInstance to use async logic when reading from the log. This happens when the leader has to catch up followers that have fallen behind.
