### PR TITLE
Create NioOLog (issue #11)

### DIFF
--- a/c5db/src/main/java/c5db/C5DB.java
+++ b/c5db/src/main/java/c5db/C5DB.java
@@ -19,6 +19,7 @@ package c5db;
 import c5db.discovery.BeaconService;
 import c5db.interfaces.C5Module;
 import c5db.interfaces.C5Server;
+import c5db.log.LogFileManager;
 import c5db.log.LogService;
 import c5db.messages.generated.CommandReply;
 import c5db.messages.generated.ModuleType;
@@ -55,8 +56,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-
-import static c5db.log.OLog.moveAwayOldLogs;
 
 
 /**
@@ -424,7 +423,7 @@ public class C5DB extends AbstractService implements C5Server {
 //            registryFile = new RegistryFile(configDirectory.baseConfigPath);
 
             // TODO this should probably be done somewhere else.
-            moveAwayOldLogs(configDirectory.baseConfigPath);
+            new LogFileManager(configDirectory.baseConfigPath).clearOldArchivedLogs(0);
 
 //            if (existingRegister(registryFile)) {
 //                recoverC5Server(conf, path, registryFile);

--- a/c5db/src/main/java/c5db/log/EntryEncoding.java
+++ b/c5db/src/main/java/c5db/log/EntryEncoding.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package c5db.log;
+
+import c5db.generated.OLogImmutableHeader;
+import c5db.generated.OLogMutableHeader;
+import c5db.replication.generated.LogEntry;
+import c5db.util.CrcInputStream;
+import com.dyuproject.protostuff.LinkBuffer;
+import com.dyuproject.protostuff.LowCopyProtobufOutput;
+import com.dyuproject.protostuff.ProtostuffIOUtil;
+import com.dyuproject.protostuff.Schema;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.zip.Adler32;
+
+import static c5db.generated.OLogMutableHeader.Type.DATA;
+import static c5db.generated.OLogMutableHeader.Type.TRUNCATION;
+
+/**
+ * Contains methods used for encoding and decoding WAL entries
+ */
+public class EntryEncoding {
+
+  /**
+   * Exception class for use when reading a bad CRC from disk
+   */
+  public static class CrcError extends IllegalStateException {
+    public CrcError(String s) {
+      super(s);
+    }
+  }
+
+  /**
+   * Contains methods for use when iterating over entries in the log.
+   */
+  static class IterationInfo {
+    final OLogImmutableHeader immutableHeader;
+    final OLogMutableHeader mutableHeader;
+    final long mutableHeaderFilePos;
+    private final InputStream inputStream;
+
+    IterationInfo(InputStream inputStream,
+                  OLogImmutableHeader immutableHeader,
+                  OLogMutableHeader mutableHeader,
+                  long mutableHeaderFilePos) {
+      this.inputStream = inputStream;
+      this.immutableHeader = immutableHeader;
+      this.mutableHeader = mutableHeader;
+      this.mutableHeaderFilePos = mutableHeaderFilePos;
+    }
+
+    long getSeqNum() {
+      return immutableHeader.getSeqNum();
+    }
+
+    long getTerm() {
+      return immutableHeader.getTerm();
+    }
+
+    ByteBuffer getContent() throws IOException {
+      final int contentLength = mutableHeader.getContentLength();
+      assert mutableHeader.getType() == DATA;
+      assert contentLength >= 0;
+      if (contentLength == 0) {
+        return ByteBuffer.allocate(0);
+      } else {
+        return getAndCheckContent(inputStream, contentLength);
+      }
+    }
+  }
+
+  /**
+   * Return a ByteBuffer[], containing the serialized form of the passed log entry, ready to be written to disk. If
+   * {@code content} is null, or if its remaining() is zero, neither the content nor the final CRC(s) will be included.
+   *
+   * @param entry    The entry to be written to disk. No position change will be performed on its ByteBuffer.
+   * @param quorumId The quorum ID.
+   * @return The array of ByteBuffers containing serialized data.
+   */
+  public static ByteBuffer[] encodeEntry(LogEntry entry, String quorumId) {
+    // TODO Future optimization: replace quorum names with an ID
+
+    try {
+      final OLogMutableHeader mutableHeader = createMutableHeader(entry);
+      final List<ByteBuffer> entryBufs = encodeDelimitedWithCrc(OLogMutableHeader.getSchema(), mutableHeader);
+
+      if (mutableHeader.getContentLength() > 0) {
+        entryBufs.addAll(writeContentWithCrc(entry.getData()));
+      }
+
+      int length = 0;
+      for (ByteBuffer b : entryBufs) {
+        length += b.remaining();
+        // TODO catch overflow?
+      }
+
+      final OLogImmutableHeader immutableHeader = new OLogImmutableHeader(
+          quorumId,
+          entry.getIndex(),
+          entry.getTerm(),
+          length);
+      final List<ByteBuffer> immutableHeaderBufs =
+          encodeDelimitedWithCrc(OLogImmutableHeader.getSchema(), immutableHeader);
+
+      return Iterables.toArray(
+          Iterables.concat(immutableHeaderBufs, entryBufs),
+          ByteBuffer.class);
+    } catch (IOException e) {
+      // This method performs no IO, so it should not actually be possible for an IOException to be thrown.
+      // But just in case...
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Return a ByteBuffer[] containing the serialized form of a truncation marker -- data that can be written
+   * over an existing entry to logically delete it.
+   *
+   * @param skipForward The next valid file position after a series of truncated entries.
+   * @return The serialized truncation marker
+   */
+  public static ByteBuffer[] encodeTruncationMarker(long skipForward) {
+    final OLogMutableHeader truncationMarker = createTruncationMarker(skipForward);
+    final List<ByteBuffer> bufs = encodeDelimitedWithCrc(OLogMutableHeader.getSchema(), truncationMarker);
+    return Iterables.toArray(bufs, ByteBuffer.class);
+  }
+
+  /**
+   * Serialize a protostuff message object, prefixed with message length, and suffixed with a 4-byte CRC.
+   *
+   * @param schema  Protostuff message schema
+   * @param message Object to serialize
+   * @param <T>     Message type
+   * @return A list of ByteBuffers containing a varInt length, followed by the message, followed by a 4-byte CRC.
+   */
+  public static <T> List<ByteBuffer> encodeDelimitedWithCrc(Schema<T> schema, T message) {
+    final Adler32 crc = new Adler32();
+    final LinkBuffer messageBuf = new LinkBuffer();
+    final LowCopyProtobufOutput lcpo = new LowCopyProtobufOutput(messageBuf);
+
+    try {
+      schema.writeTo(lcpo, message);
+
+      final int length = (int) lcpo.buffer.size();
+      final LinkBuffer lengthBuf = new LinkBuffer().writeVarInt32(length);
+
+      lengthBuf.finish().forEach(crc::update);
+      messageBuf.finish().forEach(crc::update);
+      final LinkBuffer crcBuf = new LinkBuffer(8);
+      putCrc(crcBuf, crc.getValue());
+
+      return Lists.newArrayList(
+          Iterables.concat(lengthBuf.getBuffers(), messageBuf.getBuffers(), crcBuf.finish()));
+    } catch (IOException e) {
+      // This method performs no IO, so it should not actually be possible for an IOException to be thrown.
+      // But just in case...
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Decode a message from the passed input stream, and compute and verify its CRC. This method reads
+   * data written by the method {@link EntryEncoding#encodeDelimitedWithCrc}.
+   *
+   * @param inputStream Input stream, opened for reading and positioned just before the length-prepended header
+   * @return The deserialized, constructed, validated message
+   * @throws IOException                     if a problem is encountered while reading or parsing
+   * @throws c5db.log.EntryEncoding.CrcError if the recorded CRC of the message does not match its computed CRC.
+   */
+  public static <T> T decodeAndCheckCrc(InputStream inputStream, Schema<T> schema)
+      throws IOException, CrcError {
+    // TODO this should check the length first and compare it with a passed-in maximum length
+    final T message = schema.newMessage();
+    final CrcInputStream crcStream = new CrcInputStream(inputStream, new Adler32());
+    ProtostuffIOUtil.mergeDelimitedFrom(crcStream, message, schema);
+
+    final long computedCrc = crcStream.getValue();
+    final long diskCrc = readCrc(inputStream);
+    if (diskCrc != computedCrc) {
+      throw new CrcError("CRC mismatch on deserialized message " + message.toString());
+    }
+
+    return message;
+  }
+
+  /**
+   * Create a truncation marker, used to overwrite an existing mutable header.
+   */
+  private static OLogMutableHeader createTruncationMarker(long skipForward) {
+    return new OLogMutableHeader(TRUNCATION, 0, skipForward);
+  }
+
+  /**
+   * Create an OLogMutableHeader, ready to be written to disk.
+   *
+   * @param entry Entry to be used. The data field of this entry is only used for its length, and the
+   *              length is calculated without performing any position change on the ByteBuffer.
+   * @return A new OLogEntryHeader.
+   */
+  private static OLogMutableHeader createMutableHeader(LogEntry entry) {
+    final int contentLength;
+    if (entry.getData() == null) {
+      contentLength = 0;
+    } else {
+      contentLength = entry.getData().remaining();
+    }
+
+    return new OLogMutableHeader(DATA, contentLength, 0);
+  }
+
+  /**
+   * Write the passed data to buffers, followed by one or more 4-byte CRCs.
+   *
+   * @param content non-null ByteBuffer; no reset will be performed on it.
+   * @return list of ByteBuffers
+   */
+  private static List<ByteBuffer> writeContentWithCrc(ByteBuffer content) throws IOException {
+    assert content != null;
+
+    final LinkBuffer contentBuf = new LinkBuffer();
+    final Adler32 crc = new Adler32();
+    contentBuf.writeByteBuffer(content);
+    crc.update(content);
+    putCrc(contentBuf, crc.getValue());
+    return contentBuf.finish();
+  }
+
+  /**
+   * Write a passed CRC to the passed buffer. The CRC is a 4-byte unsigned integer stored in a long; write it
+   * as (fixed length) 4 bytes.
+   *
+   * @param writeTo Buffer to write to; exactly 4 bytes will be written.
+   * @param crc     CRC to write; caller guarantees that the code is within the range:
+   *                0 <= CRC < 2^32
+   */
+  private static void putCrc(final LinkBuffer writeTo, final long crc) throws IOException {
+    // To store the CRC in an int, we need to subtract to convert it from unsigned to signed.
+    final long shiftedCrc = crc + Integer.MIN_VALUE;
+    writeTo.writeInt32(Ints.checkedCast(shiftedCrc));
+  }
+
+  private static long readCrc(InputStream inputStream) throws IOException {
+    int shiftedCrc = (new DataInputStream(inputStream)).readInt();
+    return ((long) shiftedCrc) - Integer.MIN_VALUE;
+  }
+
+  /**
+   * Read a specified number of bytes from the input stream (the "content"), then read one or more CRC codes and
+   * check the validity of the data.
+   *
+   * @param inputStream   Input stream, opened for reading and positioned just before the content
+   * @param contentLength Length of data to read from inputStream, not including any trailing CRCs
+   * @return The read content, as a ByteBuffer.
+   * @throws IOException
+   */
+  private static ByteBuffer getAndCheckContent(InputStream inputStream, int contentLength)
+      throws IOException, CrcError {
+    // TODO probably not the correct way to do this... should use IOUtils?
+    final CrcInputStream crcStream = new CrcInputStream(inputStream, new Adler32());
+    final byte[] content = new byte[contentLength];
+    final int len = crcStream.read(content);
+
+    if (len < contentLength) {
+      // Data wasn't available that we expected to be
+      throw new IllegalStateException("Reading a log entry's contents returned fewer than expected bytes");
+    }
+
+    final long computedCrc = crcStream.getValue();
+    final long diskCrc = readCrc(inputStream);
+    if (diskCrc != computedCrc) {
+      throw new CrcError("CRC mismatch on log entry contents");
+    }
+
+    return ByteBuffer.wrap(content);
+  }
+}

--- a/c5db/src/main/java/c5db/log/LogFileManager.java
+++ b/c5db/src/main/java/c5db/log/LogFileManager.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package c5db.log;
+
+import c5db.C5ServerConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.SYNC;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+public class LogFileManager {
+  private static final Logger LOG = LoggerFactory.getLogger(LogFileManager.class);
+
+  private final Path walDir;
+  private final Path archiveDir;
+
+  private File logFile = null;
+
+  // TODO should this be in its own file?
+  public static class Writer implements AutoCloseable {
+    final FileChannel fileChannel;
+
+    protected Writer(File logFile) throws IOException {
+      fileChannel = FileChannel.open(logFile.toPath(), CREATE, APPEND);
+    }
+
+    @Override
+    public void close() throws IOException {
+      fileChannel.close();
+    }
+
+    public long position() throws IOException {
+      return fileChannel.position();
+    }
+
+    public long write(ByteBuffer[] buffers) throws IOException {
+      return fileChannel.write(buffers);
+    }
+
+    public void sync() throws IOException {
+      fileChannel.force(true);
+    }
+  }
+
+  public LogFileManager(Path basePath) throws IOException {
+    this.walDir = basePath.resolve(C5ServerConstants.WAL_DIR);
+    this.archiveDir = basePath.resolve(C5ServerConstants.ARCHIVE_DIR);
+
+    createDirectoryStructure();
+    createLogFileOrFindExisting();
+  }
+
+  protected File getLogFile() {
+    return logFile;
+  }
+
+  /**
+   * Initialize this LogFileManager instance by finding an existing write-ahead log file to use, or creating
+   * a new one if an old one isn't found.
+   *
+   * @throws IOException If there was a problem creating a new file.
+   */
+  private void createLogFileOrFindExisting() throws IOException {
+    this.logFile = findExistingLogFile();
+    if (this.logFile == null) {
+      this.logFile = createNewLogFile();
+    }
+  }
+
+  private void createDirectoryStructure() throws IOException {
+    createDirsIfNecessary(walDir);
+    createDirsIfNecessary(archiveDir);
+  }
+
+  /**
+   * Create the directory at dirPath if it does not already exist.
+   *
+   * @param dirPath Path to directory to create.
+   * @throws IOException
+   */
+  private void createDirsIfNecessary(Path dirPath) throws IOException {
+    if (!dirPath.toFile().exists()) {
+      boolean success = dirPath.toFile().mkdirs();
+      if (!success) {
+        LOG.error("Creation of path {} failed", dirPath);
+        throw new IOException("Unable to setup log Path");
+      }
+    }
+  }
+
+  private File findExistingLogFile() {
+    for (File file : allFilesInDirectory(walDir)) {
+      if (file.getName().startsWith(C5ServerConstants.LOG_NAME)) {
+        LOG.info("Existing WAL found {} ; using it", file);
+        return file;
+      }
+    }
+    return null;
+  }
+
+  private File[] allFilesInDirectory(Path dirPath) {
+    File[] files = dirPath.toFile().listFiles();
+    if (files == null) {
+      return new File[]{};
+    } else {
+      return files;
+    }
+  }
+
+  private File createNewLogFile() throws IOException {
+    long fileNum = System.currentTimeMillis();
+    File newFile = walDir.resolve(C5ServerConstants.LOG_NAME + fileNum).toFile();
+
+    // TODO should we create now so that the object is in a state where a read will succeed immediately, or
+    // TODO should we wait until some other call asks to create the file?
+    boolean success = newFile.createNewFile();
+    if (!success) {
+      LOG.error("Creation of new log file failed: {}", newFile);
+      throw new IOException("Creation of log file failed");
+    }
+
+    return newFile;
+  }
+
+  public Writer getNewWriter() throws IOException {
+    return new Writer(logFile);
+  }
+
+  public FileChannel getNewInputChannel() throws IOException {
+    return FileChannel.open(logFile.toPath(), READ);
+  }
+
+  public FileChannel getNewIOChannel() throws IOException {
+    return FileChannel.open(logFile.toPath(), READ, WRITE, SYNC);
+  }
+
+  /**
+   * Move the current log file(s) to the archive directory, and prepare to use a new log file.
+   *
+   * @throws java.io.IOException
+   */
+  public void roll() throws IOException {
+    moveLogsToArchive();
+    this.logFile = createNewLogFile();
+  }
+
+  /**
+   * Move everything in the log directory to the archive directory.
+   *
+   * @throws IOException
+   */
+  void moveLogsToArchive() throws IOException {
+    for (File file : allFilesInDirectory(walDir)) {
+      boolean success = file.renameTo(archiveDir
+          .resolve(file.getName())
+          .toFile());
+      if (!success) {
+        String err = "Unable to move: " + file.getAbsolutePath() + " to " + walDir;
+        throw new IOException(err);
+      }
+    }
+  }
+
+  /**
+   * Clean out old logs.
+   *
+   * @param timestamp Only clear logs older than timestamp. Or if 0 then remove all logs.
+   * @throws IOException
+   */
+  public void clearOldArchivedLogs(long timestamp) throws IOException {
+    for (File file : allFilesInDirectory(archiveDir)) {
+      if (timestamp == 0 || file.lastModified() > timestamp) {
+        LOG.debug("Removing old log file" + file);
+        boolean success = file.delete();
+        if (!success) {
+          throw new IOException("Unable to delete file:" + file);
+        }
+      }
+    }
+  }
+
+}

--- a/c5db/src/main/java/c5db/log/LogIndexingMemoryMap.java
+++ b/c5db/src/main/java/c5db/log/LogIndexingMemoryMap.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package c5db.log;
+
+import c5db.generated.WrittenEntry;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.function.LongFunction;
+
+import static java.util.Map.Entry;
+
+/**
+ * LogIndexingProvider implementation within memory using a NavigableMap for each quorum.
+ */
+public class LogIndexingMemoryMap implements LogIndexingProvider {
+  private final long indexSegmentBits; // every 2^(this many) bytes, record the position of an entry,
+  private final Map<String, NavigableMap<Long, Long>> maps = new HashMap<>();
+  private long lastEndFilePos = 0; // Latest file position accepted into the index; i.e., the end of the last entry
+
+  private long syncUpToFileEndPos = 0;
+  private SettableFuture<Boolean> syncFuture = null;
+
+  public LogIndexingMemoryMap(int indexSegmentBits) {
+    this.indexSegmentBits = indexSegmentBits;
+  }
+
+  private NavigableMap<Long, Long> getMapForQuorum(String quorumId) {
+    if (maps.containsKey(quorumId)) {
+      return maps.get(quorumId);
+    } else {
+      NavigableMap<Long, Long> newMap = new TreeMap<>();
+      maps.put(quorumId, newMap);
+      return newMap;
+    }
+  }
+
+  private void truncateToIndex(long index, String quorumId) {
+    getMapForQuorum(quorumId).tailMap(index, true).clear();
+  }
+
+  private boolean shouldRecord(String quorumId, long filePos) {
+    NavigableMap<Long, Long> map = getMapForQuorum(quorumId);
+    if (map.isEmpty()) {
+      return true;
+    }
+    long lastOffsetNumber = map.lastEntry().getValue() >> indexSegmentBits;
+    long thisOffsetNumber = filePos >> indexSegmentBits;
+    return thisOffsetNumber > lastOffsetNumber;
+  }
+
+  @Override
+  public void accept(WrittenEntry written) {
+    final long startFilePos = written.getStartFilePos();
+    final long endFilePos = written.getEndFilePos();
+    final long index = written.getSeqNum();
+    final String quorumId = written.getQuorumId();
+
+    if (written.getTruncation()) {
+      truncateToIndex(index, quorumId);
+      return;
+    }
+
+    assert startFilePos >= lastEndFilePos;
+    assert endFilePos > lastEndFilePos;
+
+    if (shouldRecord(quorumId, startFilePos)) {
+      getMapForQuorum(quorumId).put(index, startFilePos);
+    }
+
+    lastEndFilePos = endFilePos;
+
+    if (syncFuture != null && endFilePos >= syncUpToFileEndPos) {
+      syncFuture.set(true);
+      syncFuture = null;
+    }
+  }
+
+  @Override
+  public long getPositionLowerBound(long index, String quorumId) {
+    Entry<Long, Long> entry = getMapForQuorum(quorumId).floorEntry(index);
+    return entry == null ? 0 : entry.getValue();
+  }
+
+  @Override
+  public ListenableFuture<Boolean> sync(long upToFileEndPos) {
+    if (lastEndFilePos >= upToFileEndPos) {
+      return Futures.immediateFuture(true);
+    }
+    SettableFuture<Boolean> syncCompleted = SettableFuture.create();
+    syncFuture = syncCompleted;
+    syncUpToFileEndPos = upToFileEndPos;
+    return syncCompleted;
+  }
+
+  @Override
+  public void openAndSync(Path indexPath, LongFunction<Iterable<WrittenEntry>> sendMissingEntries) {
+    // ignore path
+    sendMissingEntries.apply(lastEndFilePos).forEach(this::accept);
+  }
+}

--- a/c5db/src/main/java/c5db/log/LogIndexingProvider.java
+++ b/c5db/src/main/java/c5db/log/LogIndexingProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package c5db.log;
+
+import c5db.generated.WrittenEntry;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import java.util.function.LongFunction;
+
+/**
+ * Describes a structure that keeps track of how indexes are distributed over the byte positions of a log file.
+ * It accepts information about entries' indexes, quorum IDs, and file positions, and uses that information to
+ * provide estimates of file position for arbitrary requested indexes.
+ *
+ * TODO how will implementations of this interface notify others about IO exceptions?
+ */
+public interface LogIndexingProvider extends Consumer<WrittenEntry> {
+
+  /**
+   * Accept a log entry and its file position, and possibly incorporate this information into the map.
+   *
+   * @param entry Log entry together with written file position
+   */
+  @Override
+  void accept(WrittenEntry entry);
+
+  /**
+   * Get the file position of the entry with the greatest index less than or equal to the passed 'index' (within
+   * the passed quorum). In other words, if we want to use the information in this structure to read the entry at
+   * 'index' from the log, the result of this method is the latest byte position we can begin reading from the file
+   * without the risk that we overshoot the entry. It is an estimate of the location of index.
+   * TODO currently the implementation makes no guarantee about how good an estimate this is
+   *
+   * @param index Log index
+   * @param quorumId Quorum id
+   * @return A lower bound for the starting file position of the requested index.
+   */
+  long getPositionLowerBound(long index, String quorumId);
+
+  /**
+   * Synchronize index with the log it's indexing, by persisting any pending writes.
+   *
+   * @param upToFileEndPos Accept any pending writes up to and including the entry ending at this
+   *                                   file position.
+   * @return Future that indicates all specified writes have been accepted, and the sync operation has completed.
+   */
+  ListenableFuture<Boolean> sync(long upToFileEndPos);
+
+  /**
+   * Open the index and give it a chance to catch up to the main log, while the caller waits.
+   *
+   * @param indexPath Path to the file the index should use to persist its data
+   * @param sendMissingEntries Allow the index to sync itself up to the main log. The passed function will be
+   *                           called exactly once. The implementation will pass the function the value of
+   *                           the last file position the index knows about -- i.e., the ending file position
+   *                           of the latest log entry it has accepted. The function will receive that long, and
+   *                           return an iterable containing all entries the index needs in order to catch up to
+   *                           the main log.
+   */
+  void openAndSync(Path indexPath, LongFunction<Iterable<WrittenEntry>> sendMissingEntries);
+}

--- a/c5db/src/main/java/c5db/log/LogTermMap.java
+++ b/c5db/src/main/java/c5db/log/LogTermMap.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package c5db.log;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * Support in-memory indexing operations for getting the "term" at a given log index. An object of this class
+ * must only be used from one thread. The current implementation requires this object to be notified for every
+ * log insert; however, the object only actually stores information when the term changes.
+ *
+ * This structure doesn't know about quorums, so there needs to be a separate one of these for each quorum.
+ */
+public class LogTermMap {
+  private static final Logger LOG = LoggerFactory.getLogger(LogTermMap.class);
+  private final NavigableMap<Long, Long> map;
+
+  public LogTermMap(NavigableMap<Long, Long> initMap) {
+    map = initMap;
+  }
+
+  public LogTermMap() {
+    this(new TreeMap<>());
+  }
+
+  /**
+   * Accept an entry's (index, term) and possibly incorporate this information in the map. Index and term
+   * refer to the concepts used by the consensus algorithm. The algorithm guarantees that term is nondecreasing.
+   *
+   * @param index Log index
+   * @param term Log term
+   */
+  public void incorporate(long index, long term) {
+    final long lastTerm;
+    if (map.isEmpty()) {
+      lastTerm = 0;
+    } else {
+      lastTerm = map.lastEntry().getValue();
+    }
+
+    if (term > lastTerm) {
+      map.put(index, term);
+    } else if (term < lastTerm) {
+      LOG.error("Encountered a decreasing term, {}, where the last known term was {}", term, lastTerm);
+      throw new IllegalArgumentException("Decreasing term number");
+    }
+  }
+
+  /**
+   * This method removes information from the map. It should be used when the log has truncated some entries.
+   *
+   * @param index Index to truncate back to, inclusive.
+   */
+  public void truncateToIndex(long index) {
+    map.tailMap(index, true).clear();
+  }
+
+  /**
+   * Get the log term for a specified index, or zero if there is no preceding index such that the term can be
+   * inferred.
+   *
+   * @param index Log index
+   * @return The log term at this index
+   */
+  public long getTermAtIndex(long index) {
+    Map.Entry<Long, Long> entry = map.floorEntry(index);
+    return entry == null? 0 : entry.getValue();
+  }
+
+}

--- a/c5db/src/main/java/c5db/log/NioOLog.java
+++ b/c5db/src/main/java/c5db/log/NioOLog.java
@@ -1,0 +1,618 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package c5db.log;
+
+import c5db.generated.OLogImmutableHeader;
+import c5db.generated.OLogMutableHeader;
+import c5db.generated.WrittenEntry;
+import c5db.replication.generated.LogEntry;
+import c5db.util.C5Futures;
+import c5db.util.CheckedConsumer;
+import c5db.util.FiberOnly;
+import com.dyuproject.protostuff.ProtobufException;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.jetlang.channels.MemoryChannel;
+import org.jetlang.core.BatchExecutor;
+import org.jetlang.fibers.Fiber;
+import org.jetlang.fibers.PoolFiberFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Stack;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static c5db.generated.OLogMutableHeader.Type.TRUNCATION;
+import static c5db.log.EntryEncoding.CrcError;
+import static c5db.log.EntryEncoding.IterationInfo;
+import static c5db.log.EntryEncoding.decodeAndCheckCrc;
+import static c5db.log.EntryEncoding.encodeEntry;
+import static c5db.log.EntryEncoding.encodeTruncationMarker;
+import static c5db.log.NioOLog.WriteRequest.Type.FLUSH_QUEUE;
+import static c5db.log.NioOLog.WriteRequest.Type.QUORUM_SYNC;
+import static c5db.log.NioOLog.WriteRequest.Type.TRUNCATE;
+import static c5db.log.NioOLog.WriteRequest.Type.WRITE;
+
+/**
+ * OLog using NIO.
+ */
+public final class NioOLog implements OLog {
+  private static final Logger LOG = LoggerFactory.getLogger(NioOLog.class);
+
+  private static final int SYNC_TIMEOUT = 30; // seconds
+  private static final int READER_TIMEOUT = 15; // seconds
+  private static final int WRITER_TIMEOUT = 30; // seconds
+  private static final int INDEX_SEGMENT_BITS = 14;
+
+  private final LogFileManager logFileManager;
+  private final BatchExecutor batchExecutor;
+  private final PoolFiberFactory fiberFactory;
+
+  private final LogIndexingProvider indexingProvider = new LogIndexingMemoryMap(INDEX_SEGMENT_BITS);
+  private final Fiber indexingFiber;
+  private final MemoryChannel<WrittenEntry> indexingQueue = new MemoryChannel<>();
+
+  private LogFileManager.Writer logWriter;
+
+  /**
+   * Class to hold information specific to a single quorum
+   */
+  private static class PerQuorum {
+    final LogTermMap termMap = new LogTermMap();
+    final Queue<WriteRequest> blockedWrites = new LinkedList<>();
+
+    // truncationInProgress and lastSeqNum may be written to by two separate fibers/threads (the writer thread and
+    // a truncation thread). However, the logic of writing and truncation is such that it is impossible for these
+    // to interfere. During truncation, all writes are queued; and during a write, a truncation cannot begin.
+    boolean truncationInProgress;
+    long lastSeqNum = 0;
+
+    // Prevent reads during truncations and vice versa.
+    ReadWriteLock rwl = new ReentrantReadWriteLock(false);
+  }
+
+  private final Map<String, PerQuorum> quorumMap = new HashMap<>();
+
+  private static class WriteResult {
+    final long postFilePos;
+
+    private WriteResult(long postFilePos) {
+      this.postFilePos = postFilePos;
+    }
+  }
+
+  /**
+   * Class describing a single request to the log's write queue.
+   */
+  static final class WriteRequest {
+    enum Type {
+      WRITE,        // write the entries to the specified quorum
+      TRUNCATE,     // truncate the specified quorum to the "index" of the first element in entries
+      FLUSH_QUEUE,  // flush the writeFiber's in-memory WriteRequest queue
+      QUORUM_SYNC   // complete all queued writes for the specified quorum, including truncations
+    }
+
+    final Type type;
+    final List<LogEntry> entries;
+    final String quorumId;
+    final SettableFuture<WriteResult> future;
+
+    private WriteRequest(Type type, String quorumId, List<LogEntry> entries, SettableFuture<WriteResult> future) {
+      this.type = type;
+      this.quorumId = quorumId;
+      this.entries = entries;
+      this.future = future;
+    }
+
+    @Override
+    public String toString() {
+      return "WriteRequest{" +
+          ", type=" + type.toString() +
+          ", quorumId=\"" + quorumId +
+          "\", entries=" + entries +
+          '}';
+    }
+  }
+
+  private final Fiber writeFiber;
+  private final MemoryChannel<WriteRequest> writeQueue = new MemoryChannel<>();
+
+  public NioOLog(LogFileManager logFileManager,
+                 PoolFiberFactory fiberFactory,
+                 BatchExecutor batchExecutor) throws IOException {
+    this.logFileManager = logFileManager;
+    this.fiberFactory = fiberFactory;
+    this.batchExecutor = batchExecutor;
+
+    this.writeFiber = fiberFactory.create(batchExecutor);
+    writeQueue.subscribe(writeFiber, this::handleWriteRequest);
+    writeFiber.start();
+
+    indexingFiber = fiberFactory.create(batchExecutor);
+    indexingQueue.subscribe(indexingFiber, indexingProvider::accept);
+    indexingFiber.start();
+
+    logWriter = logFileManager.getNewWriter();
+  }
+
+  /**
+   * Retrieve the information structure for the desired quorum, creating it if it does not yet exist.
+   *
+   * @param quorumId The quorum whose information should be retrieved
+   * @return Information structure for the passed quorum.
+   */
+  private PerQuorum perQuorum(String quorumId) {
+    if (quorumMap.containsKey(quorumId)) {
+      return quorumMap.get(quorumId);
+    } else {
+      PerQuorum newInfoObject = new PerQuorum();
+      quorumMap.put(quorumId, newInfoObject);
+      return newInfoObject;
+    }
+  }
+
+  /**
+   * Run a task asynchronously, not on the caller's thread.
+   *
+   * @param run Runnable to execute.
+   */
+  private void execute(Runnable run) {
+    final Fiber fiber = fiberFactory.create(batchExecutor);
+    fiber.start();
+    fiber.execute(run);
+  }
+
+  @Override
+  public ListenableFuture<Boolean> logEntry(List<LogEntry> entries, String quorumId) {
+    final LogTermMap termMap = perQuorum(quorumId).termMap;
+    entries.forEach((LogEntry e) -> termMap.incorporate(e.getIndex(), e.getTerm()));
+
+    final SettableFuture<WriteResult> future = SettableFuture.create();
+    writeQueue.publish(new WriteRequest(WRITE, quorumId, entries, future));
+    return Futures.transform(future, (WriteResult result) -> true);
+  }
+
+  /**
+   * Process a write request. Write requests come in several types, so this method dispatches to other methods
+   * as necessary to handle particular types.
+   *
+   * @param writeRequest Request to process.
+   */
+  @FiberOnly
+  private void handleWriteRequest(final WriteRequest writeRequest) {
+    if (writeRequest.type == FLUSH_QUEUE) {
+      writeRequest.future.set(new WriteResult(0));
+      return;
+    }
+
+    final String quorumId = writeRequest.quorumId;
+    final PerQuorum quorumInfo = perQuorum(quorumId);
+
+    quorumInfo.blockedWrites.add(writeRequest);
+
+    while (!quorumInfo.truncationInProgress && !quorumInfo.blockedWrites.isEmpty()) {
+      final WriteRequest nextRequest = quorumInfo.blockedWrites.poll();
+
+      try {
+        final long currentFilePos = logWriter.position();
+
+        if (nextRequest.type == WRITE) {
+          write0(nextRequest);
+
+        } else if (nextRequest.type == QUORUM_SYNC) {
+          nextRequest.future.set(new WriteResult(currentFilePos));
+
+        } else if (nextRequest.type == TRUNCATE) {
+          final long truncateToIndex = nextRequest.entries.get(0).getIndex();
+          quorumInfo.truncationInProgress = true;
+          execute(() -> doTruncation(truncateToIndex, quorumId, currentFilePos, nextRequest.future));
+          indexingQueue.publish(new WrittenEntry(quorumId, truncateToIndex, 0, 0, true));
+        }
+      } catch (Throwable t) {
+        LOG.error("Error encountered executing write request {}: {}", nextRequest, t);
+        nextRequest.future.setException(t);
+      }
+    }
+  }
+
+  /**
+   * Write entries to the log.
+   *
+   * @param writeRequest A write request containing one or more log entries.
+   * @throws IOException
+   */
+  @FiberOnly
+  private void write0(final WriteRequest writeRequest) throws IOException {
+    assert writeRequest.type == WRITE;
+
+    String quorumId = writeRequest.quorumId;
+
+    for (LogEntry entry : writeRequest.entries) {
+      final ByteBuffer[] serializedData = encodeEntry(entry, quorumId);
+
+      final long entryStartFilePos = logWriter.position();
+      logWriter.write(serializedData);
+      final long entryEndFilePos = logWriter.position();
+
+      perQuorum(quorumId).lastSeqNum = entry.getIndex();
+      indexingQueue.publish(new WrittenEntry(
+          quorumId, entry.getIndex(), entryStartFilePos, entryEndFilePos, false));
+    }
+    final long postFilePos = logWriter.position();
+    writeRequest.future.set(new WriteResult(postFilePos));
+  }
+
+  /**
+   * Perform a truncation of the log within the specified quorum. Truncation deletes entries from tail (most
+   * recent) end of the log, going backwards until the sequence number specified, inclusive. Because the log can
+   * contain several interspersed quorums, it's not generally possible just to truncate the physical file itself.
+   * <p>
+   * The strategy is to actually mark entries deleted by overwriting their header with a truncation marker, so
+   * that future read operations know to disregard the entry. Writing starts at the latest entry in the specified
+   * quorum, and proceeds backwards, with 'start' being the last entry overwritten.
+   *
+   * @param start       The sequence number of the log entry to truncate back to; that is, delete every entry in
+   *                    this quorum where entry's seqNum >= start.
+   * @param quorumId    The quorum ID.
+   * @param skipForward A file position within this file, included in the truncation marker, as an instruction
+   *                    for readers to skip forward to a later position in the file (i.e., to skip over the
+   *                    section of deleted entries.
+   * @param future      The future to notify that the truncation operation has completed.
+   */
+  @FiberOnly
+  private void doTruncation(long start, String quorumId, long skipForward, SettableFuture<WriteResult> future) {
+    final PerQuorum quorumInfo = perQuorum(quorumId);
+
+    try (FileChannel channel = logFileManager.getNewIOChannel()) {
+      final Stack<Long> filePosStack = new Stack<>();
+
+      positionChannelForIO(channel, quorumId, start);
+      iterateEntries(channel,
+          start,
+          quorumInfo.lastSeqNum + 1,
+          quorumId,
+          (iterationInfo) -> filePosStack.push(iterationInfo.mutableHeaderFilePos));
+
+      final ByteBuffer[] truncationMarkerBufs = encodeTruncationMarker(skipForward);
+
+      final boolean hasLock = quorumInfo.rwl.writeLock().tryLock(WRITER_TIMEOUT, TimeUnit.SECONDS);
+      if (!hasLock) {
+        LOG.error("Timeout while waiting for a lock to truncate quorum \"{}\" to index {}", quorumId, start);
+        throw new TimeoutException("trylock timeout in doTruncation");
+      }
+
+      try {
+        while (!filePosStack.isEmpty()) {
+          final long filePos = filePosStack.pop();
+          channel.position(filePos);
+          channel.write(truncationMarkerBufs);
+          for (ByteBuffer buf : truncationMarkerBufs) {
+            buf.rewind();
+          }
+        }
+        channel.force(true);
+      } finally {
+        quorumInfo.rwl.writeLock().unlock();
+      }
+
+    } catch (Throwable t) {
+      LOG.error("Error encountered while performing a truncation to index {} on quorum {}: {}",
+          start, quorumId, t);
+      future.setException(t);
+      return;
+    }
+
+    quorumInfo.lastSeqNum = start - 1;
+    quorumInfo.truncationInProgress = false;
+    future.set(new WriteResult(skipForward));
+    writeQueue.publish(new WriteRequest(QUORUM_SYNC, quorumId, null, SettableFuture.create()));
+  }
+
+  @Override
+  public ListenableFuture<LogEntry> getLogEntry(long index, String quorumId) {
+    // Wrapper for the multi-entry case
+    return Futures.transform(getLogEntries(index, index + 1, quorumId),
+        (List<LogEntry> result) -> {
+          if (result.isEmpty()) {
+            return null;
+          } else {
+            return result.get(0);
+          }
+        });
+  }
+
+  @Override
+  public ListenableFuture<List<LogEntry>> getLogEntries(long start, long end, String quorumId) {
+    assert start <= end;
+    if (start == end) {
+      return Futures.immediateFuture(new ArrayList<>());
+    }
+
+    // TODO caching necessary/possible for recently-written entries?
+    SettableFuture<List<LogEntry>> resultFuture = SettableFuture.create();
+    execute(() -> {
+      List<LogEntry> results = new ArrayList<>();
+
+      try {
+        // For the sake of implementation simplicity, sync right off the bat.
+        // TODO it isn't necessarily needed to sync first; could we know whether a given index is on disk?
+        // TODO Or, could we fetch directly from the write queue?
+        quorumSync(quorumId).get(SYNC_TIMEOUT, TimeUnit.SECONDS);
+
+        try (FileChannel channel = logFileManager.getNewInputChannel()) {
+          positionChannelForIO(channel, quorumId, start);
+          results = performScanningRead(channel, start, end, quorumId);
+        }
+      } catch (Throwable t) {
+        // TODO currently a failure here will fail the entire replicator instance; that may not be necessary
+        LOG.error("Error encountered reading log entries: quorum \"{}\", requested start {} end {} - {}",
+            quorumId, start, end, t);
+        resultFuture.setException(t);
+        return;
+      }
+
+      resultFuture.set(results);
+    });
+
+    return resultFuture;
+  }
+
+  /**
+   * Using the indexing provider, position the given channel so it is ready to read the entry with the
+   * specified sequence number form the specified quorum.
+   *
+   * @param channel  FileChannel to position.
+   * @param quorumId Quorum ID.
+   * @param seqNum   Entry sequence number within the quorum.
+   * @throws IOException
+   */
+  private void positionChannelForIO(FileChannel channel, String quorumId, long seqNum) throws IOException {
+    long advanceToPos = indexingProvider.getPositionLowerBound(seqNum, quorumId);
+    channel.position(advanceToPos);
+  }
+
+  /**
+   * Perform the file read operation, over a specified index range of the log file, ignoring entries not in the
+   * specified quorum. Return all log entries found within that index range and quorum.
+   *
+   * @param channel  A FileChannel, ready for reading, and already advanced to a suitable position -- on a
+   *                 boundary between entries, and less than or equal to the position of the first entry in the
+   *                 requested range.
+   * @param start    Sequence number of the first entry to return.
+   * @param end      One beyond the sequence number of the last entry to return. This method will keep reading
+   *                 until it encounters the entry with seqNum == end - 1.
+   * @param quorumId The quorum ID; ignore any entry not in this quorum.
+   * @return The list of all entries found; or, an empty list if no entries are found.
+   * @throws IOException           If an error is encountered while reading
+   * @throws InterruptedException, TimeoutException If the method is interrupted or times out while attempting
+   *                               to acquire a read lock
+   */
+  @FiberOnly
+  private List<LogEntry> performScanningRead(FileChannel channel, long start, long end, String quorumId)
+      throws IOException, InterruptedException, TimeoutException {
+    final List<LogEntry> results = new ArrayList<>();
+
+    iterateEntries(channel, start, end, quorumId, iterationInfo -> {
+      results.add(new LogEntry(
+          iterationInfo.getTerm(),
+          iterationInfo.getSeqNum(),
+          iterationInfo.getContent()));
+    });
+
+    return results;
+  }
+
+  /**
+   * Iterate over non-deleted entries in the log, within a single quorum, executing a callback for each one
+   * (synchronously, on the caller's thread).
+   *
+   * @param channel     A FileChannel, ready for reading, and already advanced to a suitable position -- on a
+   *                    boundary between entries, and less than or equal to the position of the first entry in the
+   *                    requested range.
+   * @param start       Sequence number of the first entry to execute the callback for.
+   * @param end         One beyond the sequence number of the last entry to return. This method will keep reading
+   *                    until it encounters the entry with seqNum == end - 1.
+   * @param quorumId    Quorum ID.
+   * @param callForEach Execute this callback for each entry, passing it an IterationInfo object which describes
+   *                    the current state of the iteration, and allows the callback to access the entry's
+   *                    data.
+   * @throws IOException
+   * @throws InterruptedException
+   * @throws TimeoutException
+   */
+  @FiberOnly
+  private void iterateEntries(
+      FileChannel channel,
+      long start,
+      long end,
+      String quorumId,
+      CheckedConsumer<IterationInfo, IOException> callForEach)
+      throws IOException, InterruptedException, TimeoutException {
+
+    final InputStream inputStream = Channels.newInputStream(channel);
+    final PerQuorum quorumInfo = perQuorum(quorumId);
+
+    final boolean hasLock = quorumInfo.rwl.readLock().tryLock(READER_TIMEOUT, TimeUnit.SECONDS);
+    if (!hasLock) {
+      LOG.warn("Timed out while waiting for a lock to read the log - " +
+          "requested start {} end {} quorum \"{}\"", start, end, quorumId);
+      throw new TimeoutException("tryLock timeout in iterateEntries()");
+    }
+
+    try {
+      // TODO This loop is very tightly coupled to EntryEncoding; is there any way to abstract out the decoding logic?
+      do {
+        final OLogImmutableHeader immutableHeader = decodeAndCheckCrc(inputStream, OLogImmutableHeader.getSchema());
+        final long index = immutableHeader.getSeqNum();
+        final String entryQuorumId = immutableHeader.getQuorumId();
+        final long positionOfNextEntry = channel.position() + immutableHeader.getRemainingLength();
+
+        if (!entryQuorumId.equals(quorumId)) {
+          channel.position(positionOfNextEntry);
+          continue;
+        }
+
+        final OLogMutableHeader mutableHeader;
+        final long mutableHeaderFilePos = channel.position();
+        try {
+          mutableHeader = decodeAndCheckCrc(inputStream, OLogMutableHeader.getSchema());
+        } catch (ProtobufException | CrcError e) {
+          // TODO How to handle this? Truncate for this quorum?
+          channel.position(positionOfNextEntry);
+          continue;
+        }
+
+        if (mutableHeader.getType() == TRUNCATION) {
+          channel.position(mutableHeader.getSkipForward());
+          continue;
+        }
+
+        if (index < start) {
+          channel.position(positionOfNextEntry);
+        } else if (index >= start && index < end) {
+          // TODO Add assertions to ensure consecutive, ascending indices
+          callForEach.accept(new IterationInfo(inputStream, immutableHeader, mutableHeader, mutableHeaderFilePos));
+          channel.position(positionOfNextEntry); // TODO this may often be a no-op.
+        } else {
+          break;
+        }
+
+      } while (true);
+    } catch (EOFException ignore) {
+    } catch (ProtobufException e) {
+      LOG.error("Deserialization error encountered during log read (quorum \"{}\" start {} end {}) - " +
+          "current position is {} ", quorumId, start, end, channel.position());
+      throw e;
+    } finally {
+      quorumInfo.rwl.readLock().unlock();
+    }
+  }
+
+  @Override
+  public ListenableFuture<Boolean> truncateLog(long entryIndex, String quorumId) {
+    final SettableFuture<WriteResult> truncationComplete = SettableFuture.create();
+    final LogEntry tombstone = new LogEntry(0, entryIndex, null);
+    final WriteRequest truncationRequest = new WriteRequest(
+        TRUNCATE, quorumId, Lists.newArrayList(tombstone), truncationComplete);
+
+    writeQueue.publish(truncationRequest);
+    perQuorum(quorumId).termMap.truncateToIndex(entryIndex);
+
+    return Futures.transform(truncationComplete, (WriteResult result) -> true);
+  }
+
+  /**
+   * Get confirmation from the indexing provider that it has caught up to a given file position
+   *
+   * @param upToFileEndPos Request the index to synchronize up to
+   * @param syncFuture     After the sync completes, set this future to true (or set its exception)
+   */
+  private void syncIndexWithLog(long upToFileEndPos, SettableFuture<Boolean> syncFuture) {
+    final ListenableFuture<Boolean> indexSynced = indexingProvider.sync(upToFileEndPos);
+    C5Futures.addCallback(
+        indexSynced,
+        (bool) -> syncFuture.set(true),
+        syncFuture::setException,
+        indexingFiber);
+  }
+
+  /**
+   * Wait for all WriteRequests to the specified quorum to complete. In other words, if a truncation or write
+   * was requested prior to this method being called, this method guarantees that that it will have completed
+   * when the returned future is done.
+   *
+   * @param quorumId The quorum ID to wait for.
+   * @return A future that will complete after all pending writes and truncations to that quorum have completed.
+   */
+  private ListenableFuture<WriteResult> quorumSync(String quorumId) {
+    final SettableFuture<WriteResult> syncComplete = SettableFuture.create();
+    writeQueue.publish(new WriteRequest(QUORUM_SYNC, quorumId, null, syncComplete));
+    return syncComplete;
+  }
+
+  @Override
+  public ListenableFuture<Boolean> sync() {
+    final SettableFuture<WriteResult> queueFlushed = SettableFuture.create();
+    final SettableFuture<Boolean> syncComplete = SettableFuture.create();
+
+    C5Futures.addCallback(
+        queueFlushed,
+        (WriteResult result) -> {
+          if (syncComplete.isCancelled()) {
+            return;
+          }
+          try {
+            for (String quorum : quorumMap.keySet()) {
+              if (quorumMap.get(quorum).truncationInProgress) {
+                quorumSync(quorum).get(SYNC_TIMEOUT, TimeUnit.SECONDS);
+              }
+            }
+            logWriter.sync();
+            syncIndexWithLog(result.postFilePos, syncComplete);
+          } catch (Throwable t) {
+            LOG.error("Error encountered during sync(): {}", t);
+            syncComplete.setException(t);
+          }
+        },
+        syncComplete::setException,
+        writeFiber);
+
+    writeQueue.publish(new WriteRequest(FLUSH_QUEUE, null, null, queueFlushed));
+
+    return syncComplete;
+  }
+
+  @Override
+  public long getLogTerm(long index, String quorumId) {
+    return perQuorum(quorumId).termMap.getTermAtIndex(index);
+  }
+
+  @Override
+  public void roll() throws IOException, ExecutionException, InterruptedException {
+    logWriter.close();
+    quorumMap.clear();
+    logFileManager.roll();
+    logWriter = logFileManager.getNewWriter();
+  }
+
+  @Override
+  public void close() throws IOException {
+    writeFiber.dispose();
+    indexingFiber.dispose();
+    logWriter.close();
+  }
+
+}

--- a/c5db/src/main/java/c5db/log/OLog.java
+++ b/c5db/src/main/java/c5db/log/OLog.java
@@ -17,240 +17,89 @@
 
 package c5db.log;
 
-import c5db.C5ServerConstants;
-import c5db.generated.Log;
 import c5db.replication.generated.LogEntry;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+
 import java.io.IOException;
-import java.nio.channels.ClosedChannelException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 
-public class OLog implements AutoCloseable {
-  private static final Logger LOG = LoggerFactory.getLogger(OLog.class);
-  private static final long RETRY_WAIT_TIME = 100;
-  private final Path walDir;
-  private final Path archiveLogPath;
-  long fileNum;
-  Path logPath;
-  private FileOutputStream logOutputStream;
+public interface OLog extends AutoCloseable {
 
-  public OLog(Path basePath) throws IOException {
-      this.fileNum = System.currentTimeMillis();
-      this.walDir = basePath.resolve(C5ServerConstants.WAL_DIR);
-      this.archiveLogPath = basePath.resolve(C5ServerConstants.ARCHIVE_DIR);
-      this.logPath = walDir.resolve(C5ServerConstants.LOG_NAME + fileNum);
+  /**
+   * Append the passed entries to the log.
+   *
+   * @param entries  Non-null list of zero or more entries.
+   * @param quorumId Quorum id these entries should be logged under
+   * @return Future indicating completion. Failure will be indicated by exception.
+   */
+  ListenableFuture<Boolean> logEntry(List<LogEntry> entries, String quorumId);
 
+  /**
+   * Asynchronously retrieve the entry at the given index in the given quorum.
+   *
+   * @param index    Index of entry to retrieve
+   * @param quorumId Quorum id of entry to retrieve
+   * @return Future containing the log entry upon completion, or null if not found.
+   */
+  ListenableFuture<LogEntry> getLogEntry(long index, String quorumId);
 
-      if (!logPath.getParent().toFile().exists()) {
-          boolean success = logPath.getParent().toFile().mkdirs();
-          if (!success) {
-              throw new IOException("Unable to setup logPath");
-          }
-      }
+  /**
+   * Asynchronously retrieve a range of entries from index start, inclusive, to index end, exclusive. Returns every
+   * entry in the specified range. Any entries retrieved are guaranteed to have consecutive indices.
+   *
+   * @param start    First index in range
+   * @param end      One beyond the last index in the desired range; must be greater than or equal to start. If this
+   *                 equals start, a list of length zero will be retrieved.
+   * @param quorumId Quorum id of entries to retrieve
+   * @return Future containing a list of log entries upon completion.
+   */
+  ListenableFuture<List<LogEntry>> getLogEntries(long start, long end, String quorumId);
 
-      if (!archiveLogPath.toFile().exists()) {
-          boolean success = archiveLogPath.toFile().mkdirs();
-          if (!success) {
-              throw new IOException("Unable to setup archive Log Path");
-          }
-      }
-      logOutputStream = new FileOutputStream(logPath.toFile(), true);
-  }
+  /**
+   * Logically delete entries from the tail of the log.
+   *
+   * @param entryIndex Delete entries back to, and including, this index,
+   * @param quorumId   Quorum id within which to delete entries
+   * @return Future indicating completion.
+   */
+  ListenableFuture<Boolean> truncateLog(long entryIndex, String quorumId);
 
-    public static void moveAwayOldLogs(final Path basePath)
-            throws IOException {
-        Path walPath = basePath.resolve(C5ServerConstants.WAL_DIR);
-        Path archiveLogPath = basePath.resolve(C5ServerConstants.ARCHIVE_DIR);
-        File[] files = walPath.toFile().listFiles();
+  /**
+   * Flush all pending writes to the physical medium.
+   * TODO should this also be specified to sync with any indexing provider?
+   *
+   * @return Future indicating completion or exception.
+   */
+  ListenableFuture<Boolean> sync();
 
-        if (files == null) {
-            return;
-        }
+  /**
+   * Retrieve the "term" (i.e., leader or election term) corresponding to the given pair (index, quorum)
+   *
+   * @param index    Log entry index
+   * @param quorumId Log entry quorum
+   * @return The term for this entry, or zero if not found.
+   */
+  long getLogTerm(long index, String quorumId);
 
-        if (!archiveLogPath.toFile().exists()) {
-            boolean success = archiveLogPath.toFile().mkdirs();
-            if (!success) {
-                throw new IOException("Unable to setup archive Log Path");
-            }
-        }
+  /**
+   * Save off and close log file, and begin a new log file.
+   *
+   * @throws IOException
+   * @throws ExecutionException
+   * @throws InterruptedException
+   */
+  @SuppressWarnings("UnusedDeclaration")
+  void roll() throws IOException, ExecutionException, InterruptedException;
 
-        for (File file : files) {
-            boolean success = file.renameTo(archiveLogPath
-                    .resolve(file.getName())
-                    .toFile());
-            if (!success) {
-                String err = "Unable to move: " + file + " to " + archiveLogPath;
-                throw new IOException(err);
-            }
-        }
-    }
-
-    public void sync(SettableFuture<Boolean> syncComplete) throws IOException {
-        boolean success = false;
-        do {
-            try {
-                // TODO this needs to be processed on a background thread, not while the caller is waiting. Async notification.
-                this.logOutputStream.flush();
-                this.logOutputStream.getChannel().force(false);
-                success = true;
-                syncComplete.set(true);
-            } catch (ClosedChannelException e) {
-                try {
-                    Thread.sleep(RETRY_WAIT_TIME);
-                } catch (InterruptedException e1) {
-                    throw new IOException(e1);
-                }
-            }
-        } while (!success);
-    }
-
-    @Override
-    public void close() throws IOException {
-        SettableFuture<Boolean> syncComplete = SettableFuture.create();
-        this.sync(syncComplete);
-        try {
-            syncComplete.get();
-        } catch (InterruptedException | ExecutionException e) {
-            throw new IOException(e);
-        }
-        this.logOutputStream.close();
-    }
-
-    public void roll() throws IOException, ExecutionException, InterruptedException {
-        this.close();
-        boolean success = logPath.toFile().renameTo(archiveLogPath
-                .resolve(logPath.toFile().getName())
-                .toFile());
-        if (!success) {
-            String err = "Unable to move: " + logPath + " to " + archiveLogPath;
-            throw new IOException(err);
-        }
-
-        this.fileNum = System.currentTimeMillis();
-        this.logPath = Paths.get(this.walDir.toString(), C5ServerConstants.LOG_NAME + fileNum);
-
-        logOutputStream = new FileOutputStream(this.logPath.toFile(),
-                true);
-    }
-
-    /**
-     * Clean out old logs
-     *
-     * @param timestamp Only clear logs older than timestamp. Or if 0 then always
-     *                  remove.
-     * @throws IOException
-     */
-    public void clearOldLogs(long timestamp) throws IOException {
-        File[] files = this.archiveLogPath.toFile().listFiles();
-        if (files == null) {
-            return;
-        }
-
-        for (File file : files) {
-            LOG.debug("Removing old log file" + file);
-            if (timestamp == 0 || file.lastModified() > timestamp) {
-                boolean success = file.delete();
-                if (!success) {
-                    throw new IOException("Unable to delete file:" + file);
-                }
-            }
-        }
-    }
-
-    /**
-     * @param index
-     * @param quorumId
-     * @return The log data for a node at an index or null if not found.
-     */
-
-    private Log.OLogEntry getLogDataFromDisk(long index, String quorumId)
-            throws IOException, ExecutionException, InterruptedException {
-        SettableFuture<Boolean> f = SettableFuture.create();
-        this.sync(f);
-        f.get();
-
-        FileInputStream fileInputStream = new FileInputStream(logPath.toFile());
-        Log.OLogEntry nextEntry;
-
-        do {
-            // TODO Handle tombestones
-            try {
-            nextEntry = Log.OLogEntry.parseDelimitedFrom(fileInputStream);
-            } catch (IOException e) {
-                return null;
-            }
-            // EOF
-            if (nextEntry == null) {
-                return null;
-            }
-        } while (!nextEntry.getQuorumId().equals(quorumId) || nextEntry.getIndex() != index);
-
-        return nextEntry;
-    }
-
-    public ListenableFuture<Boolean> logEntry(List<Log.OLogEntry> entries, String quorumId) {
-        SettableFuture<Boolean> completionNotification = SettableFuture.create();
-        try {
-            for (Log.OLogEntry entry : entries) {
-                entry.writeDelimitedTo(this.logOutputStream);
-            }
-            completionNotification.set(true);
-            return completionNotification;
-        } catch (IOException e) {
-            completionNotification.setException(e);
-            return completionNotification;
-        }
-    }
-
-    public LogEntry getLogEntry(long index, String quorumId) {
-        try {
-            Log.OLogEntry ologEntry = getLogDataFromDisk(index, quorumId);
-            if (ologEntry == null) {
-              return null;
-            }
-            return new LogEntry(ologEntry.getTerm(),
-                    ologEntry.getIndex(),
-                    ologEntry.getValue().asReadOnlyByteBuffer());
-        } catch (IOException | InterruptedException | ExecutionException e) {
-            throw new RuntimeException("CRASH!", e);
-        }
-    }
-
-    public long getLogTerm(long index, String quorumId) {
-        try {
-            Log.OLogEntry logEntry = getLogDataFromDisk(index, quorumId);
-            if (logEntry == null) return 0;
-            return logEntry.getTerm();
-        } catch (IOException | ExecutionException | InterruptedException e) {
-
-            throw new RuntimeException("CRASH!", e);
-        }
-    }
-
-    public ListenableFuture<Boolean> truncateLog(long entryIndex, String quorumId) {
-        try {
-            SettableFuture<Boolean> truncateComplete = SettableFuture.create();
-            Log.OLogEntry entry = Log.OLogEntry.newBuilder()
-                    .setTombStone(true)
-                    .setIndex(entryIndex)
-                    .setQuorumId(quorumId).build();
-
-            entry.writeDelimitedTo(this.logOutputStream);
-            this.sync(truncateComplete);
-            return truncateComplete;
-        } catch (Exception e) {
-            throw new RuntimeException("CRASH!");
-        }
-    }
+  /**
+   * Dispose of held resources. This method does not perform a sync() first -- the caller should sync if necessary.
+   * The rationale for not performing a sync is to give the caller flexibility with whether or not to close
+   * immediately, or asynchronously.
+   *
+   * @throws IOException If an error occurs closing a file stream.
+   */
+  void close() throws IOException;
 
 }

--- a/c5db/src/main/java/c5db/util/CheckedConsumer.java
+++ b/c5db/src/main/java/c5db/util/CheckedConsumer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package c5db.util;
+
+/**
+ * Interface to permit the use of a lambda that throws a checked exception.
+ *
+ * @param <T>   Type accepted by the consumer; analogous to {@code Consumer<T>}
+ * @param <E>   Type of the exception thrown
+ */
+public interface CheckedConsumer<T, E extends Throwable>  {
+
+  void accept(T t) throws E;
+}

--- a/c5db/src/main/java/c5db/util/CrcInputStream.java
+++ b/c5db/src/main/java/c5db/util/CrcInputStream.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package c5db.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.Checksum;
+
+/**
+ * InputStream decorator which computes a running CRC on every byte read. The CRC object is
+ * passed in on construction, and its value can be obtained any time. This class does no buffering
+ * on its input.
+ */
+@SuppressWarnings("NullableProblems")
+public class CrcInputStream extends FilterInputStream {
+  private Checksum crc;
+
+  public CrcInputStream(InputStream inputStream, Checksum crc) {
+    super(inputStream);
+    this.crc = crc;
+  }
+
+  public long getValue() {
+    return crc.getValue();
+  }
+
+  public void reset() {
+    crc.reset();
+  }
+
+  @Override
+  public int read() throws IOException {
+    int b = super.read();
+    crc.update(b);
+    return b;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    int bytesRead = super.read(b, off, len);
+    if (bytesRead > 0) {
+      crc.update(b, off, bytesRead);
+    }
+    return bytesRead;
+  }
+}

--- a/c5db/src/main/resources/Log.proto
+++ b/c5db/src/main/resources/Log.proto
@@ -95,14 +95,28 @@ message TruncationMarker {
     optional int64 file_byte_offset = 4;
 }
 
-
-message OLogEntry {
+message OLogImmutableHeader {
     optional string quorumId = 1;
-    optional int64 index = 2;
+    optional int64 seqNum = 2; // same as the "index" in the terminology of the replication algorithm
+    optional int64 term = 3; // election term
+    optional int32 remainingLength = 4; // length of remainder of the log entry after the CRC of this header.
+}
 
-    optional bool tombStone = 3;
+message OLogMutableHeader {
+    enum Type {
+        DATA = 1;
+        TRUNCATION = 2;
+    }
 
-    optional int64 term = 4;
+    required Type type = 1;
+    optional int32 contentLength = 2; // Length of entry content (payload), not including CRCs
+    optional int64 skipForward = 3; // File position of the end of the truncation; used only for TRUNCATION messages
+}
 
-    optional bytes value = 5;
+message WrittenEntry {
+    optional string quorumId = 1;
+    optional int64 seqNum = 2;
+    optional int64 startFilePos = 3;
+    optional int64 endFilePos = 4;
+    optional bool truncation = 5;
 }

--- a/c5db/src/test/java/c5db/log/EntryEncodingTest.java
+++ b/c5db/src/test/java/c5db/log/EntryEncodingTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package c5db.log;
+
+import c5db.generated.OLogImmutableHeader;
+import com.dyuproject.protostuff.Schema;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.List;
+
+import static c5db.log.EntryEncoding.decodeAndCheckCrc;
+import static c5db.log.EntryEncoding.encodeDelimitedWithCrc;
+import static org.junit.Assert.assertEquals;
+
+public class EntryEncodingTest {
+  private static Schema<OLogImmutableHeader> SCHEMA = OLogImmutableHeader.getSchema();
+
+  private static void assertSameMessage(OLogImmutableHeader messageA, OLogImmutableHeader messageB) {
+    assertEquals(messageA.getSeqNum(), messageB.getSeqNum());
+    assertEquals(messageA.getTerm(), messageB.getTerm());
+    assertEquals(messageA.getQuorumId(), messageB.getQuorumId());
+    assertEquals(messageA.getRemainingLength(), messageB.getRemainingLength());
+  }
+
+  private static void testEncodeThenDecodeAndCheckCrc(final OLogImmutableHeader entryToTest) throws IOException {
+    final PipedOutputStream pipedOutputStream = new PipedOutputStream();
+    final InputStream readFromMe = new PipedInputStream(pipedOutputStream);
+    final WritableByteChannel writeToMe = Channels.newChannel(pipedOutputStream);
+
+    final List<ByteBuffer> serialized = encodeDelimitedWithCrc(SCHEMA, entryToTest);
+    for (ByteBuffer buffer : serialized) {
+      writeToMe.write(buffer);
+    }
+
+    final OLogImmutableHeader result = decodeAndCheckCrc(readFromMe, SCHEMA);
+
+    assertSameMessage(entryToTest, result);
+  }
+
+  @Test
+  public void testThatEncodeAndDecodeAreInverses() throws Exception {
+    testEncodeThenDecodeAndCheckCrc(
+        new OLogImmutableHeader("quorumId", Long.MAX_VALUE, Long.MAX_VALUE, Integer.MAX_VALUE));
+    testEncodeThenDecodeAndCheckCrc(
+        new OLogImmutableHeader(
+            "tableName,\\x00,0.48445111e3a0dc70a14610c61b025d60.", Long.MIN_VALUE, Long.MIN_VALUE, Integer.MIN_VALUE));
+  }
+}

--- a/c5db/src/test/java/c5db/log/LogFileManagerTest.java
+++ b/c5db/src/test/java/c5db/log/LogFileManagerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package c5db.log;
+
+import c5db.C5CommonTestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogFileManagerTest {
+  private static Path testDirectory = (new C5CommonTestUtil()).getDataTestDir("log-file-manager");
+  private LogFileManager logFileManager;
+
+  private static void writeInts(LogFileManager.Writer writer, int start, int end) throws Exception {
+    for (int i = start; i < end; i++) {
+      ByteBuffer buffer = ByteBuffer.allocate(Integer.SIZE / Byte.SIZE);
+      buffer.asIntBuffer().put(i);
+      writer.write(new ByteBuffer[]{buffer});
+    }
+  }
+
+  private static void assertReadInts(DataInputStream dataInputStream, int start, int end) throws Exception {
+    for (int i = start; i < end; i++) {
+      assertEquals(i, dataInputStream.readInt());
+    }
+  }
+
+  private static void assertIsAtEOF(InputStream inputStream) throws Exception {
+    try {
+      assertEquals(-1, inputStream.read());
+    } catch (EOFException ignore) {
+      // pass
+    }
+  }
+
+  private static DataInputStream getDataInputStream(LogFileManager logFileManager) throws Exception {
+    return new DataInputStream(Channels.newInputStream(logFileManager.getNewInputChannel()));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    logFileManager = new LogFileManager(testDirectory);
+    logFileManager.moveLogsToArchive();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    logFileManager.moveLogsToArchive();
+  }
+
+
+  @Test
+  public void testWritingAndThenReadingFromSameFile() throws Exception {
+    try (
+        LogFileManager.Writer writer = logFileManager.getNewWriter();
+        DataInputStream dataInputStream1 = getDataInputStream(logFileManager);
+        DataInputStream dataInputStream2 = getDataInputStream(logFileManager)
+    ) {
+      writeInts(writer, 0, 100);
+      assertReadInts(dataInputStream1, 0, 100);
+
+      writeInts(writer, 100, 200);
+      assertReadInts(dataInputStream1, 100, 200);
+      assertReadInts(dataInputStream2, 0, 200);
+
+      assertIsAtEOF(dataInputStream1);
+      assertIsAtEOF(dataInputStream2);
+    }
+  }
+
+  @Test
+  public void testArchivingLogAndStartingNewLog() throws Exception {
+    try (
+        LogFileManager.Writer writer = logFileManager.getNewWriter();
+        DataInputStream dataInputStream = getDataInputStream(logFileManager)
+    ) {
+      writeInts(writer, 0, 100);
+      assertReadInts(dataInputStream, 0, 100);
+      assertIsAtEOF(dataInputStream);
+    }
+
+    logFileManager.roll();
+
+    try (
+        DataInputStream dataInputStream = getDataInputStream(logFileManager)
+    ) {
+      assertIsAtEOF(dataInputStream);
+    }
+  }
+
+  @Test
+  public void testFindAndUseExistingLog() throws Exception {
+    try (
+        LogFileManager.Writer writer = logFileManager.getNewWriter()
+    ) {
+      writeInts(writer, 0, 100);
+    }
+
+    LogFileManager newLogFileManager = new LogFileManager(testDirectory);
+
+    try (
+        DataInputStream dataInputStream = getDataInputStream(newLogFileManager)
+    ) {
+      assertReadInts(dataInputStream, 0, 100);
+      assertIsAtEOF(dataInputStream);
+    }
+  }
+}

--- a/c5db/src/test/java/c5db/log/MooringTest.java
+++ b/c5db/src/test/java/c5db/log/MooringTest.java
@@ -17,7 +17,6 @@
 
 package c5db.log;
 
-import c5db.generated.Log;
 import c5db.replication.ReplicatorLogAbstraction;
 import c5db.replication.generated.LogEntry;
 import com.google.common.collect.Lists;
@@ -39,18 +38,18 @@ import static org.mockito.Mockito.when;
 public class MooringTest {
   ReplicatorLogAbstraction log;
 
-  private static OLog makeMockAsyncOLog() {
+  private static OLog makeMockLog() {
     // Create a mock OLog, to be used by Mooring, whose logEntry method simulates a logging operation that does
     // not "complete" synchronously. It simulates this by returning an "unset" future.
     OLog mock = mock(OLog.class);
-    when(mock.logEntry(anyListOf(Log.OLogEntry.class), anyString()))
+    when(mock.logEntry(anyListOf(LogEntry.class), anyString()))
         .thenReturn(SettableFuture.create());
     return mock;
   }
 
   @Before
   public final void setUp() {
-    log = new Mooring(makeMockAsyncOLog(), "quorumId");
+    log = new Mooring(makeMockLog(), "quorumId");
   }
 
   @After

--- a/c5db/src/test/java/c5db/log/OLogTest.java
+++ b/c5db/src/test/java/c5db/log/OLogTest.java
@@ -18,19 +18,35 @@
 package c5db.log;
 
 import c5db.C5CommonTestUtil;
-import c5db.generated.Log;
 import c5db.replication.generated.LogEntry;
+import c5db.util.ExceptionHandlingBatchExecutor;
+import c5db.util.ThrowFiberExceptions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.protobuf.ByteString;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.commons.lang.ArrayUtils;
+import org.jetlang.channels.MemoryChannel;
+import org.jetlang.core.BatchExecutor;
+import org.jetlang.fibers.Fiber;
+import org.jetlang.fibers.PoolFiberFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -39,7 +55,154 @@ import static org.junit.Assert.assertNull;
 
 public class OLogTest {
   private static Path testDirectory;
+  private static final int TIMEOUT = 10; //seconds
+  private LogFileManager logFileManager;
   private OLog log;
+  private Random deterministicDataSequence = null; // Used as a pre-seeded data source for at least one test
+
+  @Rule
+  public ThrowFiberExceptions throwFiberExceptions = new ThrowFiberExceptions(this);
+
+  private final PoolFiberFactory fiberFactory = new PoolFiberFactory(Executors.newCachedThreadPool());
+  private final BatchExecutor batchExecutor = new ExceptionHandlingBatchExecutor(throwFiberExceptions);
+
+
+  private static void assertSameEntry(LogEntry entry1, LogEntry entry2) {
+    assertEquals(entry1.getIndex(), entry2.getIndex());
+    assertEquals(entry1.getTerm(), entry2.getTerm());
+    assertArrayEquals(entry1.getData().array(), entry2.getData().array());
+  }
+
+  private static void assertSameEntryLists(List<LogEntry> list1, List<LogEntry> list2) {
+    assertEquals(list1.size(), list2.size());
+    for (int i = 0; i != list1.size(); i++) {
+      assertSameEntry(list1.get(i), list2.get(i));
+    }
+  }
+
+  /**
+   * Helper method which wraps assertSameEntryLists, to more cleanly deal with the case where the actual
+   * list is returned by a future.
+   *
+   * @return a future indicating that the assertion has taken place.
+   */
+  private static ListenableFuture<Boolean> assertEqualsFuture(List<LogEntry> expected,
+                                                              ListenableFuture<List<LogEntry>> actual) {
+    return Futures.transform(actual, (List<LogEntry> result) -> {
+      assertSameEntryLists(expected, result);
+      return true;
+    });
+  }
+
+  /**
+   * Get a log entry, and wait for its future to complete, for the sake of brevity below
+   */
+  private static LogEntry syncGetEntry(OLog log, long index, String quorumId) throws Exception {
+    return log.getLogEntry(index, quorumId).get(TIMEOUT, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Get a sequence of log entries, and wait for the future to complete, for the sake of brevity below
+   */
+  private static List<LogEntry> syncGetLogEntries(OLog log, long start, long end, String quorumId)
+      throws Exception {
+    return log.getLogEntries(start, end, quorumId).get(TIMEOUT, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Method to create a LogEntry, as a wrapper to insulate from proto* changes
+   */
+  private static LogEntry makeEntry(long index, long term, String stringData) {
+    return new LogEntry(term, index, ByteBuffer.wrap(stringData.getBytes()));
+  }
+
+  private static <T> List<T> cherryPickIndexes(List<T> inputList, Set<Integer> indexes) {
+    List<T> result = Lists.newArrayListWithExpectedSize(indexes.size());
+    for (int i = 0; i < inputList.size(); i++) {
+      if (indexes.contains(i)) {
+        result.add(inputList.get(i));
+      }
+    }
+    return result;
+  }
+
+  private static <T> void waitForAll(List<ListenableFuture<T>> futures) throws Exception {
+    for (ListenableFuture<T> future : futures) {
+      future.get(TIMEOUT, TimeUnit.SECONDS);
+    }
+  }
+
+  Fiber syncCallFiber = fiberFactory.create(batchExecutor);
+  MemoryChannel<Boolean> syncCallsMade = new MemoryChannel<>();
+
+  /**
+   * Return a doctored instance of LogFileManager for use by tests. A complete mock would be impractical, since
+   * the log relies on this object to produce nontrivial side effects. However, this is brittle;
+   * TODO give LogFileManager some kind of hook or facility to let the test observe file sync; or, have it use
+   * TODO some kind of abstract Writer factory?
+   *
+   * @return Anonymous subclass of LogFileManager, overridden to return Writers that let us observe their sync().
+   * @throws Exception
+   */
+  private LogFileManager makeLogFileManager() throws Exception {
+    return new LogFileManager(testDirectory) {
+      @Override
+      public Writer getNewWriter() throws IOException {
+        return new Writer(getLogFile()) {
+          @Override
+          public void sync() throws IOException {
+            super.sync();
+            syncCallsMade.publish(true);
+          }
+        };
+      }
+    };
+  }
+
+  private String getArbitraryStringData() {
+    // Some variable-length data to use for tests;
+    return String.valueOf(deterministicDataSequence.nextLong());
+  }
+
+  /**
+   * Create a list of LogEntry from a given start index (inclusive) to a given end index (exclusive).
+   */
+  private List<LogEntry> makeEntryList(long start, long end) {
+    List<LogEntry> entries = Lists.newArrayList();
+    for (long index = start; index < end; index++) {
+      entries.add(makeEntry(index, Math.floorDiv(index, 7) + 1, getArbitraryStringData()));
+    }
+    return entries;
+  }
+
+  /**
+   * Execute a simple script against the log. The "script" is an array of numbers. Positive numbers indicate that
+   * an entry should be logged with that index. Negative numbers indicate that a truncation operation should be
+   * made back to index equal to the absolute value of the negative number. Term is increased after each truncation
+   * operation. Data logged is derived from a sequence of pseudorandom numbers starting from a particular seed.
+   * The entries that were logged are returned, not including truncations.
+   * <p>
+   * All operations (truncations and writes) result in futures, which are added to the passed list.
+   */
+  private List<LogEntry> runLogScript(List<Long> script, String quorumId, List<ListenableFuture<Boolean>> futures)
+      throws Exception {
+    long term = 1;
+    List<LogEntry> entriesLogged = Lists.newArrayList();
+
+    for (long scriptItem : script) {
+      long index = Math.abs(scriptItem);
+      if (scriptItem < 0) {
+        futures.add(log.truncateLog(index, quorumId));
+        term++;
+      } else {
+        String data = getArbitraryStringData();
+        LogEntry entry = makeEntry(index, term, data);
+        entriesLogged.add(entry);
+        futures.add(log.logEntry(Lists.newArrayList(entry), quorumId));
+      }
+    }
+    return entriesLogged;
+  }
 
   @BeforeClass
   public static void setTestDirectory() {
@@ -48,88 +211,221 @@ public class OLogTest {
     }
   }
 
-  /**
-   * Method to quickly create an OLogEntry, to make the test methods in this class more readable
-   */
-  private Log.OLogEntry makeEntry(String quorumId, long index, long term, String stringData) {
-    return Log.OLogEntry.newBuilder()
-        .setQuorumId(quorumId)
-        .setIndex(index)
-        .setTombStone(false)
-        .setTerm(term)
-        .setValue(ByteString.copyFrom(stringData.getBytes()))
-        .build();
-  }
-
-  private byte[] getBytes(ByteBuffer byteBuffer) {
-    byte[] b = new byte[byteBuffer.remaining()];
-    byteBuffer.get(b);
-    return b;
-  }
-
   @Before
-  public final void setUp() throws IOException {
-    // interestingly clearOldLogs never actually does anything because it only
-    // affects the 'archive' path. this call will move stuff from wal -> old_wal
-    OLog.moveAwayOldLogs(testDirectory);
-    log = new OLog(testDirectory);
+  public final void setUp() throws Exception {
+    logFileManager = makeLogFileManager();
+    logFileManager.moveLogsToArchive();
+    log = new NioOLog(logFileManager, fiberFactory, batchExecutor);
+    syncCallFiber.start();
+    deterministicDataSequence = new Random(2231983);
   }
 
   @After
-  public final void tearDown() throws IOException {
-    OLog.moveAwayOldLogs(testDirectory);
+  public final void tearDown() throws Exception {
+    log.close();
+    logFileManager.moveLogsToArchive();
+    syncCallFiber.dispose();
+    deterministicDataSequence = null;
   }
 
   @Test
-  public void testGetLogEntryEmptyLog() {
-    assertNull(log.getLogEntry(1, "quorumId"));
-    assertNull(log.getLogEntry(0, "quorumId"));
+  public void testGetLogEntryEmptyLog() throws Exception {
+    String quorumId = "quorum";
+    assertNull(syncGetEntry(log, 1, quorumId));
+    assertNull(syncGetEntry(log, 0, quorumId));
   }
 
   @Test
-  public void testGetLogEntry() {
+  public void testGetLogEntry() throws Exception {
     String quorumId = "quorum";
     String anotherQuorumId = "another quorum";
 
-    List<Log.OLogEntry> entries = Lists.newArrayList(
-        makeEntry(anotherQuorumId, 1, 1, "first"),
-        makeEntry(quorumId, 2, 1, "second"),
-        makeEntry(quorumId, 4, 2, "third"));
-    log.logEntry(entries, quorumId); // Presently, the quorumId parameter here is ignored.
+    List<LogEntry> entries = Lists.newArrayList(
+        makeEntry(1, 1, "first"),
+        makeEntry(2, 1, "second"),
+        makeEntry(4, 2, "third"));
+    log.logEntry(entries.subList(0, 1), anotherQuorumId);
+    log.logEntry(entries.subList(1, 3), quorumId);
 
-    assertNull(log.getLogEntry(1, quorumId));
-    assertEquals(entries.get(0).getTerm(), log.getLogEntry(1, anotherQuorumId).getTerm());
-    assertArrayEquals(entries.get(0).getValue().toByteArray(),
-        getBytes(log.getLogEntry(1, anotherQuorumId).getData()));
+    assertNull(syncGetEntry(log, 1, quorumId));
+    assertSameEntry(entries.get(0), syncGetEntry(log, 1, anotherQuorumId));
 
-    assertEquals(entries.get(1).getTerm(), log.getLogEntry(2, quorumId).getTerm());
-    assertArrayEquals(entries.get(1).getValue().toByteArray(),
-        getBytes(log.getLogEntry(2, quorumId).getData()));
-    assertNull(log.getLogEntry(2, anotherQuorumId));
+    assertNull(syncGetEntry(log, 2, anotherQuorumId));
+    assertSameEntry(entries.get(1), syncGetEntry(log, 2, quorumId));
 
-    assertNull(log.getLogEntry(3, quorumId));
+    assertNull(syncGetEntry(log, 3, quorumId));
 
-    assertEquals(entries.get(2).getTerm(), log.getLogEntry(4, quorumId).getTerm());
-    assertArrayEquals(entries.get(2).getValue().toByteArray(),
-        getBytes(log.getLogEntry(4, quorumId).getData()));
-    assertNull(log.getLogEntry(4, anotherQuorumId));
+    assertSameEntry(entries.get(2), syncGetEntry(log, 4, quorumId));
+    assertNull(syncGetEntry(log, 4, anotherQuorumId));
   }
 
   @Test
-  public void testGetLogEntries() {
+  public void testGetLogEntries() throws Exception {
     // Within this test, assume the log has no holes and all entries are in a particular quorum
     final String quorumId = "yet another quorum";
-    final List<Log.OLogEntry> entries = Lists.newArrayList(
-        makeEntry(quorumId, 1, 1, "first"),
-        makeEntry(quorumId, 2, 1, "second"),
-        makeEntry(quorumId, 3, 2, "third"),
-        makeEntry(quorumId, 4, 2, "fourth"));
-    final List<LogEntry> emptyList = Lists.newArrayList();
-    final List<LogEntry> outputEntries = Lists.transform(entries,
-        (e) -> new LogEntry(e.getTerm(), e.getIndex(), ByteBuffer.wrap(e.getValue().toByteArray())));
+    final List<LogEntry> entries = Lists.newArrayList(
+        makeEntry(1, 1, "first"),
+        makeEntry(2, 1, "second"),
+        makeEntry(3, 2, "third"),
+        makeEntry(4, 2, "fourth"));
 
     log.logEntry(entries, quorumId);
+    assertSameEntryLists(
+        entries.subList(1, 4),
+        syncGetLogEntries(log, 2, 6, quorumId));
 
-    // TODO test OLog method to retrieve multiple entries
+    assertSameEntryLists(
+        entries.subList(0, 2),
+        syncGetLogEntries(log, 1, 3, quorumId));
+
+    assertSameEntryLists(
+        entries.subList(2, 3),
+        syncGetLogEntries(log, 3, 4, quorumId));
+
+    assertSameEntryLists(
+        Lists.newArrayList(),
+        syncGetLogEntries(log, 1, 1, quorumId));
+  }
+
+  @Test
+  public void testQueuedWrites() throws Exception {
+    final String quorumId = "q";
+    long[] script = {1, 2, 3, -1, 1, 2, 3, 4, 5, 6, 7};
+    List<ListenableFuture<Boolean>> scriptOperations = Lists.newArrayList();
+    List<LogEntry> entriesLogged = runLogScript(
+        Arrays.asList(ArrayUtils.toObject(script)), quorumId, scriptOperations);
+
+    // Writes should appear to immediately take effect when checking term
+    for (int i = 1; i <= 7; i++) {
+      assertEquals(2, log.getLogTerm(i, quorumId));
+    }
+
+    assertSameEntry(entriesLogged.get(9), syncGetEntry(log, 7, quorumId));
+    waitForAll(scriptOperations);
+  }
+
+  @Test
+  public void testThatReadsWaitForTruncationsInProgress() throws Exception {
+    final String firstQuorumId = "first quorum";
+    final String secondQuorumId = "second quorum";
+
+    List<LogEntry> firstEntries = makeEntryList(1, 500);
+    List<LogEntry> secondEntries = makeEntryList(126, 130);
+
+    log.logEntry(firstEntries, firstQuorumId);
+    log.truncateLog(251, firstQuorumId);
+    log.logEntry(secondEntries, secondQuorumId);
+
+    // Even though the the first quorum has just received a large truncation request, this read should "see"
+    // that the truncation has already taken place. In practice, that might be because the log is doing some
+    // kind of in-memory caching of the unwritten truncation, or it might be that the log doesn't let this
+    // read complete until the truncation is processed. This test doesn't care which possibility.
+    assertSameEntryLists(firstEntries.subList(224, 250), syncGetLogEntries(log, 225, 275, firstQuorumId));
+
+    // A second quorum requests and gets its data. The reason for including this in the test is to make sure
+    // concurrent writes and reads to a second quorum aren't affected by the first quorum waiting.
+    assertSameEntryLists(secondEntries, syncGetLogEntries(log, 126, 130, secondQuorumId));
+  }
+
+  @Test
+  public void testMultipleOverlappingTruncationsWithinOneQuorum() throws Exception {
+    final String quorumId = "q";
+    long[] script = {1, 2, 3, 4, 5, 6, -4, 4, 5, -3, 3, 4, 5, 6, 7, 8, -6, 6, 7, -6, 6, 7, 8, 9, -8};
+
+    List<ListenableFuture<Boolean>> scriptOperations = Lists.newArrayList();
+    List<LogEntry> entriesLogged = runLogScript(
+        Arrays.asList(ArrayUtils.toObject(script)), quorumId, scriptOperations);
+    List<LogEntry> expectedEntries = cherryPickIndexes(entriesLogged, Sets.newHashSet(0, 1, 8, 9, 10, 16, 17));
+
+    waitForAll(scriptOperations);
+
+    List<ListenableFuture<Boolean>> asyncAssertions = ImmutableList.of(
+        assertEqualsFuture(expectedEntries.subList(0, 7), log.getLogEntries(1, 12, quorumId)),
+        assertEqualsFuture(expectedEntries.subList(1, 4), log.getLogEntries(2, 5, quorumId)),
+        assertEqualsFuture(expectedEntries.subList(0, 2), log.getLogEntries(1, 3, quorumId)),
+        assertEqualsFuture(expectedEntries.subList(3, 7), log.getLogEntries(4, 8, quorumId)),
+        assertEqualsFuture(Lists.newArrayList(), log.getLogEntries(8, 10, quorumId)));
+
+    for (LogEntry entry : expectedEntries) {
+      assertEquals(entry.getTerm(), log.getLogTerm(entry.getIndex(), quorumId));
+    }
+
+    waitForAll(asyncAssertions);
+  }
+
+  @Test
+  public void testGetLogEntriesWhenThereAreMultipleInterspersedQuorums() throws Exception {
+    String testQuorumId = "the quorum being tested";
+    String[] quorums = {"B", "C", "D", "E"};
+    long[] script = {1, 2, 3, 4, 5, 6, -6, 6, 7, -6, -5, -4, -3, 3, 4, 5, 6, -6, 6, 7, 8};
+    List<LogEntry> entriesLogged = Lists.newArrayList();
+    List<ListenableFuture<Boolean>> scriptOperations = Lists.newArrayList();
+
+    for (long scriptItem : script) {
+      List<Long> itemAsList = Lists.newArrayList(scriptItem);
+      entriesLogged.addAll(runLogScript(itemAsList, testQuorumId, scriptOperations));
+      for (String quorumId : quorums) {
+        runLogScript(itemAsList, quorumId, scriptOperations);
+      }
+    }
+
+    List<LogEntry> expectedEntries = cherryPickIndexes(entriesLogged, Sets.newHashSet(0, 1, 8, 9, 10, 12, 13, 14));
+    waitForAll(scriptOperations);
+
+    for (LogEntry entry : expectedEntries) {
+      assertEquals(entry.getTerm(), log.getLogTerm(entry.getIndex(), testQuorumId));
+    }
+
+    List<ListenableFuture<Boolean>> asyncAssertions = ImmutableList.of(
+        assertEqualsFuture(expectedEntries.subList(0, 4), log.getLogEntries(1, 5, testQuorumId)),
+        assertEqualsFuture(expectedEntries.subList(3, 8), log.getLogEntries(4, 9, testQuorumId)),
+        assertEqualsFuture(expectedEntries.subList(0, 8), log.getLogEntries(1, 9, testQuorumId)));
+
+    waitForAll(asyncAssertions);
+  }
+
+  @Test
+  public void testSyncAfterMultipleSmallWrites() throws Exception {
+    final int numEntriesInTest = 1000;
+    final int numBytesInEntriesContent = 5;
+    final String quorumId = "Q";
+    final List<LogEntry> entriesLogged = Lists.newArrayList();
+
+    // Write many small entries to the log
+    for (long index = 1; index <= numEntriesInTest; index++) {
+      final byte[] byteDataPerEntry = new byte[numBytesInEntriesContent];
+      deterministicDataSequence.nextBytes(byteDataPerEntry);
+      ByteBuffer data = ByteBuffer.wrap(byteDataPerEntry);
+
+      LogEntry entry = new LogEntry(1, index, data);
+      log.logEntry(Lists.newArrayList(entry), quorumId);
+      entriesLogged.add(entry);
+    }
+
+    // This test affects log implementations that queue or batch their writes. Without the following sync,
+    // it is highly unlikely (although theoretically possible) that this test will pass.
+    log.sync().get(TIMEOUT, TimeUnit.SECONDS);
+
+    // Simulate a shutdown of the log (does not sync, in and of itself)
+    log.close();
+
+    // Another log opens the same file (replace the previous one, so the @After method doesn't notice)
+    log = new NioOLog(logFileManager, fiberFactory, batchExecutor);
+    assertSameEntryLists(entriesLogged, syncGetLogEntries(log, 1, numEntriesInTest + 1, quorumId));
+  }
+
+  @Test
+  public void testThatLogCallsUnderlyingSync() throws Exception {
+    // It would be ideal to test logging a single large block of data to the log, then cause a catastrophic
+    // interruption, such that if the log's sync() method had not been used, the lack of an underlying fsync
+    // call would cause data loss. Such a hypothetical test would therefore use sync() before the interruption,
+    // and so verify that all data was correctly persisted to disk. However, it is not simple to reliably
+    // create such a catastrophic failure within the unit testing framework. So this test will simply verify
+    // that the file descriptor's sync() method is called then the log's sync() method is.
+
+    SettableFuture<Boolean> notificationThatSyncWasCalled = SettableFuture.create();
+    log.sync();
+    syncCallsMade.subscribe(syncCallFiber, notificationThatSyncWasCalled::set);
+    notificationThatSyncWasCalled.get(2, TimeUnit.SECONDS);
   }
 }

--- a/c5db/src/test/java/c5db/util/CrcInputStreamTest.java
+++ b/c5db/src/test/java/c5db/util/CrcInputStreamTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014  Ohm Data
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package c5db.util;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.zip.Adler32;
+import java.util.zip.Checksum;
+
+import static org.junit.Assert.assertEquals;
+
+public class CrcInputStreamTest {
+
+  @Test
+  public void testDirectlyCheckingCrc() throws Exception {
+    final byte[] b = "The quick brown fox jumps over the \000\001\002\003".getBytes(Charset.forName("UTF-8"));
+    final int len = b.length;
+
+    // naively compute CRC
+    Checksum crc = new Adler32();
+    crc.update(b, 0, len);
+    final long expectedCrc = crc.getValue();
+
+    final InputStream inputStream = new ByteArrayInputStream(b);
+    final CrcInputStream crcInputStream = new CrcInputStream(inputStream, new Adler32());
+
+    // Read 4 individual bytes, then do byte array reads until the end of the input.
+    for (int i = 0; i < 4; i++) {
+      //noinspection ResultOfMethodCallIgnored
+      crcInputStream.read();
+    }
+
+    int bytesRead;
+    final byte[] buffer = new byte[3];
+    do {
+      bytesRead = crcInputStream.read(buffer);
+    } while (bytesRead > 0);
+
+    assertEquals(expectedCrc, crcInputStream.getValue());
+  }
+}


### PR DESCRIPTION
This patch replaces the existing WAL, OLog, per https://github.com/OhmData/c5/issues/11 . It also addresses https://github.com/OhmData/c5/issues/48 . And it provides additional tests of OLog.

Please review and comment.
