### PR TITLE
Adjust timeouts and numbers of attempts with concurrency tests

### DIFF
--- a/c5db/src/test/java/c5db/log/QuorumDelegatingLogConcurrencyTest.java
+++ b/c5db/src/test/java/c5db/log/QuorumDelegatingLogConcurrencyTest.java
@@ -53,7 +53,7 @@ public class QuorumDelegatingLogConcurrencyTest {
 
   @Test(timeout = 5000)
   public void isThreadSafeWithRespectToLoggingFromMultipleQuorumsWithEachQuorumItsOwnThread() throws Exception {
-    final int numThreads = 200;
+    final int numThreads = 150;
     final int numAttempts = 5;
 
     runAConcurrencyTestSeveralTimes(numThreads, numAttempts, this::runMultipleQuorumThreadSafetyTest);
@@ -62,7 +62,7 @@ public class QuorumDelegatingLogConcurrencyTest {
   @Test(timeout = 5000)
   public void isThreadSafeWithRespectToCallingCloseFromMultipleThreads() throws Exception {
     final int numThreads = 100;
-    final int numAttempts = 25;
+    final int numAttempts = 10;
 
     runAConcurrencyTestSeveralTimes(numThreads, numAttempts, this::runCloseThreadSafetyTest);
   }

--- a/c5db/src/test/java/c5db/util/WrappingKeySerializingExecutorTest.java
+++ b/c5db/src/test/java/c5db/util/WrappingKeySerializingExecutorTest.java
@@ -141,7 +141,7 @@ public class WrappingKeySerializingExecutorTest {
     assertThat(log, containsRecordOfEveryTask());
   }
 
-  @Test(timeout = 3000)
+  @Test(timeout = 5000)
   public void acceptsSubmissionsFromMultipleThreadsConcurrentlyWithEachThreadADifferentKey() throws Exception {
     final int numThreads = 20;
     final int numAttempts = 150;
@@ -149,7 +149,7 @@ public class WrappingKeySerializingExecutorTest {
     runAConcurrencyTestSeveralTimes(numThreads, numAttempts, this::executeAMultikeySubmissionConcurrencyStressTest);
   }
 
-  @Test(timeout = 3000)
+  @Test(timeout = 5000)
   public void acceptsSubmissionsFromMultipleThreadsConcurrentlyWithinOneKeyWithExecutionOrderUndetermined()
       throws Exception {
     final int numThreads = 50;
@@ -158,7 +158,7 @@ public class WrappingKeySerializingExecutorTest {
     runAConcurrencyTestSeveralTimes(numThreads, numAttempts, this::executeASingleKeyConcurrencyStressTest);
   }
 
-  @Test(timeout = 3000)
+  @Test(timeout = 5000)
   public void shutsDownIdempotently() throws Exception {
     final int numThreads = 10;
     final int numAttempts = 300;
@@ -166,7 +166,7 @@ public class WrappingKeySerializingExecutorTest {
     runAConcurrencyTestSeveralTimes(numThreads, numAttempts, this::executeAShutdownIdempotencyStressTest);
   }
 
-  @Test(timeout = 3000)
+  @Test(timeout = 5000)
   public void shutsDownAtomicallyWithRespectToSubmitAttempts() throws Exception {
     final int numThreads = 5;
     final int numAttempts = 100;


### PR DESCRIPTION
This patch tries to get the thread safety test durations under 1s, to make accidental timeout less likely on slow machines or with GC pauses.
