### PR TITLE
Better handling of resources for PoolFiberFactory executor services

### DIFF
--- a/c5db-replicator/src/test/java/c5db/replication/InRamSim.java
+++ b/c5db-replicator/src/test/java/c5db/replication/InRamSim.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -167,7 +168,8 @@ public class InRamSim {
   private final RequestChannel<RpcRequest, RpcWireReply> rpcChannel = new MemoryRequestChannel<>();
   private final Channel<IndexCommitNotice> commitNotices = new MemoryChannel<>();
   private final Fiber rpcFiber;
-  private final PoolFiberFactory fiberPool;
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
+  private final PoolFiberFactory fiberPool = new PoolFiberFactory(executorService);
   private final BatchExecutor batchExecutor;
   private final Channel<RpcMessage> replyChannel = new MemoryChannel<>();
   private final Channel<ReplicatorInstanceEvent> eventChannel = new MemoryChannel<>();
@@ -185,7 +187,6 @@ public class InRamSim {
    * @param batchExecutor         The jetlang batch executor for the simulation's fibers to use.
    */
   public InRamSim(long electionTimeout, long electionTimeoutOffset, BatchExecutor batchExecutor) {
-    this.fiberPool = new PoolFiberFactory(Executors.newCachedThreadPool());
     this.batchExecutor = batchExecutor;
     this.electionTimeout = electionTimeout;
     this.electionTimeoutOffset = electionTimeoutOffset;
@@ -396,5 +397,6 @@ public class InRamSim {
       repl.dispose();
     }
     fiberPool.dispose();
+    executorService.shutdownNow();
   }
 }

--- a/c5db-util/src/test/java/c5db/util/WrappingKeySerializingExecutorTest.java
+++ b/c5db-util/src/test/java/c5db/util/WrappingKeySerializingExecutorTest.java
@@ -22,6 +22,7 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.States;
 import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,6 +55,11 @@ public class WrappingKeySerializingExecutorTest {
 
   @SuppressWarnings("unchecked")
   private final CheckedSupplier<Integer, Exception> task = context.mock(CheckedSupplier.class);
+
+  @After
+  public void shutdownExecutorService() {
+    fixedThreadExecutor.shutdownNow();
+  }
 
   @Test
   public void runsTasksSubmittedToItAndReturnsTheirResult() throws Exception {

--- a/c5db/src/test/java/c5db/control/ControlServiceTest.java
+++ b/c5db/src/test/java/c5db/control/ControlServiceTest.java
@@ -29,8 +29,8 @@ import org.jetlang.channels.MemoryRequestChannel;
 import org.jetlang.channels.Request;
 import org.jetlang.channels.RequestChannel;
 import org.jetlang.channels.Session;
+import org.jetlang.core.RunnableExecutorImpl;
 import org.jetlang.fibers.Fiber;
-import org.jetlang.fibers.PoolFiberFactory;
 import org.jetlang.fibers.ThreadFiber;
 import org.jmock.Expectations;
 import org.jmock.api.Action;
@@ -46,7 +46,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 
 import static c5db.FutureActions.returnFutureWithException;
 import static c5db.FutureActions.returnFutureWithValue;
@@ -71,7 +70,6 @@ public class ControlServiceTest {
 
   private final NioEventLoopGroup acceptConnectionGroup = new NioEventLoopGroup(1);
   private final NioEventLoopGroup ioWorkerGroup = new NioEventLoopGroup();
-  private final PoolFiberFactory fiberFactory = new PoolFiberFactory(Executors.newFixedThreadPool(2));
   private final C5Server server = context.mock(C5Server.class);
   private final DiscoveryModule discoveryModule = context.mock(DiscoveryModule.class);
 
@@ -81,7 +79,7 @@ public class ControlServiceTest {
   private int modulePortUnderTest;
 
   private final RequestChannel<CommandRpcRequest<?>, CommandReply> serverRequests = new MemoryRequestChannel<>();
-  private final Fiber ourFiber = new ThreadFiber();
+  private final Fiber ourFiber = new ThreadFiber(new RunnableExecutorImpl(), "control-service-test-fiber", false);
 
   @Before
   public void before() {
@@ -104,7 +102,7 @@ public class ControlServiceTest {
 
     controlService = new ControlService(
         server,
-        fiberFactory.create(),
+        new ThreadFiber(new RunnableExecutorImpl(), "control-service-fiber", false),
         acceptConnectionGroup,
         ioWorkerGroup,
         modulePortUnderTest

--- a/c5db/src/test/java/c5db/regionserver/RegionServerTest.java
+++ b/c5db/src/test/java/c5db/regionserver/RegionServerTest.java
@@ -65,6 +65,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class RegionServerTest {
@@ -80,7 +81,8 @@ public class RegionServerTest {
   private final NioEventLoopGroup ioWorkerGroup = new NioEventLoopGroup();
   private final ChannelHandlerContext ctx = context.mock(ChannelHandlerContext.class);
   private final TabletModule tabletModule = context.mock(TabletModule.class);
-  private final PoolFiberFactory fiberFactory = new PoolFiberFactory(Executors.newFixedThreadPool(2));
+  private final ExecutorService fiberFactoryExecutor = Executors.newFixedThreadPool(2);
+  private final PoolFiberFactory fiberFactory = new PoolFiberFactory(fiberFactoryExecutor);
   private final C5Server server = context.mock(C5Server.class);
   private final Random random = new Random();
   private final int port = 10000 + random.nextInt(100);
@@ -117,6 +119,8 @@ public class RegionServerTest {
   @After
   public void after() throws ExecutionException, InterruptedException {
     regionServerService.stop();
+    fiberFactory.dispose();
+    fiberFactoryExecutor.shutdownNow();
   }
 
   @Test(expected = RegionNotFoundException.class)

--- a/c5db/src/test/java/c5db/tablet/RootTabletLeaderBehaviorTest.java
+++ b/c5db/src/test/java/c5db/tablet/RootTabletLeaderBehaviorTest.java
@@ -36,8 +36,9 @@ import c5db.tablet.tabletCreationBehaviors.RootTabletLeaderBehavior;
 import io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.jetlang.channels.MemoryRequestChannel;
+import org.jetlang.core.RunnableExecutorImpl;
 import org.jetlang.fibers.Fiber;
-import org.jetlang.fibers.PoolFiberFactory;
+import org.jetlang.fibers.ThreadFiber;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.jmock.lib.concurrent.Synchroniser;
@@ -50,8 +51,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static c5db.AsyncChannelAsserts.assertEventually;
 import static c5db.AsyncChannelAsserts.waitForReply;
@@ -68,9 +67,8 @@ public class RootTabletLeaderBehaviorTest {
   private C5Server c5Server = context.mock(C5Server.class, "mockC5Server");
   private DiscoveryModule discoveryModule = context.mock(DiscoveryModule.class);
   int processors = Runtime.getRuntime().availableProcessors();
-  ExecutorService executors = Executors.newFixedThreadPool(processors);
-  PoolFiberFactory fiberPool = new PoolFiberFactory(executors);
-  Fiber serviceFiber = fiberPool.create();
+  private final Fiber serviceFiber =
+      new ThreadFiber(new RunnableExecutorImpl(), "root-leader-behavior-test-fiber", false);
   private final NioEventLoopGroup acceptConnectionGroup = new NioEventLoopGroup(1);
   private final NioEventLoopGroup ioWorkerGroup = new NioEventLoopGroup();
 

--- a/c5db/src/test/java/c5db/tablet/TabletServiceTest.java
+++ b/c5db/src/test/java/c5db/tablet/TabletServiceTest.java
@@ -30,11 +30,13 @@ import org.jetlang.fibers.PoolFiberFactory;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static c5db.FutureActions.returnFutureWithValue;
@@ -48,7 +50,8 @@ public class TabletServiceTest {
   public final JUnitRuleMockery context = new JUnitRuleMockery() {{
     setThreadingPolicy(sync);
   }};
-  PoolFiberFactory poolFiberFactory = new PoolFiberFactory(Executors.newSingleThreadExecutor());
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  PoolFiberFactory poolFiberFactory = new PoolFiberFactory(executorService);
 
   DiscoveryModule discoveryModule = context.mock(DiscoveryModule.class);
   ControlModule controlModule = context.mock(ControlModule.class);
@@ -88,6 +91,12 @@ public class TabletServiceTest {
     });
     tabletService = new TabletService(c5Server);
     tabletService.start().get();
+  }
+
+  @After
+  public void shutdownExecutorService() {
+    poolFiberFactory.dispose();
+    executorService.shutdownNow();
   }
 
   @Test


### PR DESCRIPTION
When a PoolFiberFactory is created with some ExecutorService, not only does the factory need to be dispose()'d, but the service needs to be shutdown separately. This PR fixes several places that wasn't happening. In cases where the pool was only used to create() a single fiber, ThreadFibers have been used instead.
